### PR TITLE
Add support for DLL exports in Win32 platforms

### DIFF
--- a/@library/@openxlsx/CMakeLists.txt
+++ b/@library/@openxlsx/CMakeLists.txt
@@ -30,6 +30,16 @@ if(CHARCONV_RESULT)
 endif()
 
 #=======================================================================================================================
+# Enable dllspec if it's Win32 target
+#=======================================================================================================================
+get_target_property(TARGET_TYPE OpenXLSX TYPE)
+if (WIN32 AND (TARGET_TYPE STREQUAL "SHARED_LIBRARY"))
+    set(BUILD_SHARED 1)
+    target_compile_definitions(OpenXLSX "/DINBUILD=1")
+endif()
+configure_file(${CMAKE_CURRENT_LIST_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h)
+
+#=======================================================================================================================
 # Set compiler flags
 #=======================================================================================================================
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -191,7 +201,8 @@ target_include_directories(OpenXLSX
         PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/implementation/headers
         PUBLIC
-        ${CMAKE_CURRENT_LIST_DIR}/interfaces/c++/headers)
+        ${CMAKE_CURRENT_LIST_DIR}/interfaces/c++/headers
+        ${CMAKE_CURRENT_BINARY_DIR})
 
 # ===== Set output directories for targets to (staged) installation directory ===== #
 set_target_properties(OpenXLSX PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${OPENXLSX_INSTALLDIR}/lib)
@@ -200,6 +211,7 @@ set_target_properties(OpenXLSX PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${OPENXLSX_IN
 # ===== Copy header files to (staged) install directory ===== #
 file(REMOVE_RECURSE ${OPENXLSX_INSTALLDIR}/include/)
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/interfaces/c++/headers/ DESTINATION ${OPENXLSX_INSTALLDIR}/include/OpenXLSX)
+file(COPY ${CMAKE_CURRENT_BINARY_DIR}/config.h DESTINATION ${OPENXLSX_INSTALLDIR}/include/OpenXLSX)
 
 #=======================================================================================================================
 # Install OpenXLSX Library

--- a/@library/@openxlsx/config.h.cmake
+++ b/@library/@openxlsx/config.h.cmake
@@ -43,89 +43,23 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 
  */
 
-#ifndef OPENXLSX_XLCELL_H
-#define OPENXLSX_XLCELL_H
+#ifndef OPENXLSX_CONFIG_H
+#define OPENXLSX_CONFIG_H
 
-#include "config.h"
-#include "XLDefinitions.h"
-#include "XLCellReference.h"
-#include "XLCellValue.h"
+#cmakedefine BUILD_SHARED @BUILD_SHARED@
 
-namespace OpenXLSX {
-    namespace Impl {
-        class XLCell;
-    } // namespace Impl
+#ifdef WIN32
+  #ifdef BUILD_SHARED
+    #ifdef INBUILD
+      #define OPENXLSX_EXPORT __declspec(dllexport)
+    #else //INBUILD
+      #define OPENXLSX_EXPORT __declspec(dllimport)
+    #endif //INBUILD
+  #else //BUILD_SHARED
+    #define OPENXLSX_EXPORT
+  #endif //BUILD_SHARED
+#else //WIN32
+  #define OPENXLSX_EXPORT
+#endif //WIN32
 
-    /**
-     * @brief
-     */
-    class OPENXLSX_EXPORT XLCell {
-    public:
-
-        /**
-         * @brief
-         * @param cell
-         */
-        explicit XLCell(Impl::XLCell& cell);
-
-        /**
-         * @brief
-         * @param other
-         */
-        XLCell(const XLCell& other) = default;
-
-        /**
-         * @brief
-         * @param other
-         */
-        XLCell(XLCell&& other) = default;
-
-        /**
-         * @brief
-         */
-        virtual ~XLCell() = default;
-
-        /**
-         * @brief
-         * @param other
-         * @return
-         */
-        XLCell& operator=(const XLCell& other) = default;
-
-        /**
-         * @brief
-         * @param other
-         * @return
-         */
-        XLCell& operator=(XLCell&& other) = default;
-
-        /**
-         * @brief
-         * @return
-         */
-        XLCellValue Value();
-
-        /**
-         * @brief
-         * @return
-         */
-        const XLCellValue Value() const;
-
-        /**
-         * @brief
-         * @return
-         */
-        XLValueType ValueType() const;
-
-        /**
-         * @brief
-         * @return
-         */
-        const XLCellReference CellReference() const;
-
-    private:
-        Impl::XLCell* m_cell; /**<  */
-    };
-}  // namespace OpenXLSX
-
-#endif //OPENXLSX_XLCELL_H
+#endif //OPENXLSX_CONFIG_H

--- a/@library/@openxlsx/interfaces/c++/headers/XLCellRange.h
+++ b/@library/@openxlsx/interfaces/c++/headers/XLCellRange.h
@@ -47,6 +47,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #define OPENXLSX_XLCELLRANGE_H
 
 #include <vector>
+#include "config.h"
 #include "XLCell.h"
 
 using XLCellIterator = std::vector<OpenXLSX::XLCell>::iterator;
@@ -57,6 +58,8 @@ namespace OpenXLSX {
         class XLCellRange;
     } // namespace Impl
 
+    // We can't mark XLCellRange as __declspec(dllexport) because Impl::XLCellRange is incomplete type.
+    // Instance it, we mark all functions as exportable
     /**
      * @brief
      */
@@ -67,24 +70,24 @@ namespace OpenXLSX {
          * @brief
          * @param range
          */
-        explicit XLCellRange(Impl::XLCellRange range);
+        OPENXLSX_EXPORT explicit XLCellRange(Impl::XLCellRange range);
 
         /**
          * @brief
          * @param other
          */
-        XLCellRange(const XLCellRange& other);
+        OPENXLSX_EXPORT XLCellRange(const XLCellRange& other);
 
         /**
          * @brief
          * @param other
          */
-        XLCellRange(XLCellRange&& other) = default;
+        OPENXLSX_EXPORT XLCellRange(XLCellRange&& other) = default;
 
         /**
          * @brief
          */
-        virtual ~XLCellRange();
+        OPENXLSX_EXPORT virtual ~XLCellRange();
 
         /**
          * @brief
@@ -92,7 +95,7 @@ namespace OpenXLSX {
          * @param column
          * @return
          */
-        XLCell Cell(unsigned long row, unsigned int column);
+        OPENXLSX_EXPORT XLCell Cell(unsigned long row, unsigned int column);
 
         /**
          * @brief
@@ -100,54 +103,54 @@ namespace OpenXLSX {
          * @param column
          * @return
          */
-        const XLCell Cell(unsigned long row, unsigned int column) const;
+        OPENXLSX_EXPORT const XLCell Cell(unsigned long row, unsigned int column) const;
 
         /**
          * @brief
          * @return
          */
-        unsigned long NumRows() const;
+        OPENXLSX_EXPORT unsigned long NumRows() const;
 
         /**
          * @brief
          * @return
          */
-        unsigned int NumColumns() const;
+        OPENXLSX_EXPORT unsigned int NumColumns() const;
 
         /**
          * @brief
          * @param state
          */
-        void Transpose(bool state) const;
+        OPENXLSX_EXPORT void Transpose(bool state) const;
 
         /**
          * @brief
          * @return
          */
-        XLCellIterator begin();
+        OPENXLSX_EXPORT XLCellIterator begin();
 
         /**
          * @brief
          * @return
          */
-        XLCellIteratorConst begin() const;
+        OPENXLSX_EXPORT XLCellIteratorConst begin() const;
 
         /**
          * @brief
          * @return
          */
-        XLCellIterator end();
+        OPENXLSX_EXPORT XLCellIterator end();
 
         /**
          * @brief
          * @return
          */
-        XLCellIteratorConst end() const;
+        OPENXLSX_EXPORT XLCellIteratorConst end() const;
 
         /**
          * @brief
          */
-        void Clear();
+        OPENXLSX_EXPORT void Clear();
 
     private:
 

--- a/@library/@openxlsx/interfaces/c++/headers/XLCellReference.h
+++ b/@library/@openxlsx/interfaces/c++/headers/XLCellReference.h
@@ -49,6 +49,8 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #include <string>
 #include <memory>
 
+#include "config.h"
+
 namespace OpenXLSX {
     namespace Impl {
         class XLCellReference;
@@ -64,94 +66,94 @@ namespace OpenXLSX {
          * @brief
          * @param sheet
          */
-        explicit XLCellReference(const Impl::XLCellReference& sheet);
+        OPENXLSX_EXPORT explicit XLCellReference(const Impl::XLCellReference& sheet);
 
         /**
          * @brief
          * @param cellAddress
          */
-        explicit XLCellReference(const std::string& cellAddress = "");
+        OPENXLSX_EXPORT explicit XLCellReference(const std::string& cellAddress = "");
 
         /**
          * @brief
          * @param row
          * @param column
          */
-        XLCellReference(unsigned long row, unsigned int column);
+        OPENXLSX_EXPORT XLCellReference(unsigned long row, unsigned int column);
 
         /**
          * @brief
          * @param other
          */
-        XLCellReference(const XLCellReference& other);
+        OPENXLSX_EXPORT XLCellReference(const XLCellReference& other);
 
         /**
          * @brief
          * @param other
          */
-        XLCellReference(XLCellReference&& other) = default;
+        OPENXLSX_EXPORT XLCellReference(XLCellReference&& other) = default;
 
         /**
          * @brief
          */
-        virtual ~XLCellReference();
-
-        /**
-         * @brief
-         * @param other
-         * @return
-         */
-        XLCellReference& operator=(const XLCellReference& other);
+        OPENXLSX_EXPORT virtual ~XLCellReference();
 
         /**
          * @brief
          * @param other
          * @return
          */
-        XLCellReference& operator=(XLCellReference&& other) = default;
+        OPENXLSX_EXPORT XLCellReference& operator=(const XLCellReference& other);
+
+        /**
+         * @brief
+         * @param other
+         * @return
+         */
+        OPENXLSX_EXPORT XLCellReference& operator=(XLCellReference&& other) = default;
 
         /**
          * @brief
          * @return
          */
-        unsigned long Row();
+        OPENXLSX_EXPORT unsigned long Row();
 
         /**
          * @brief
          * @param row
          */
-        void SetRow(unsigned long row);
+        OPENXLSX_EXPORT void SetRow(unsigned long row);
 
         /**
          * @brief
          * @return
          */
-        unsigned int Column();
+        OPENXLSX_EXPORT unsigned int Column();
 
         /**
          * @brief
          * @param column
          */
-        void SetColumn(unsigned int column);
+        OPENXLSX_EXPORT void SetColumn(unsigned int column);
 
         /**
          * @brief
          * @param row
          * @param column
          */
-        void SetRowAndColumn(unsigned long row, unsigned int column);
+        OPENXLSX_EXPORT void SetRowAndColumn(unsigned long row, unsigned int column);
 
         /**
          * @brief
          * @return
          */
-        std::string Address() const;
+        OPENXLSX_EXPORT std::string Address() const;
 
         /**
          * @brief
          * @param address
          */
-        void SetAddress(const std::string& address);
+        OPENXLSX_EXPORT void SetAddress(const std::string& address);
 
     private:
         std::unique_ptr<Impl::XLCellReference> m_cellReference; /**< */

--- a/@library/@openxlsx/interfaces/c++/headers/XLCellValue.h
+++ b/@library/@openxlsx/interfaces/c++/headers/XLCellValue.h
@@ -46,6 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCELLVALUE_H
 #define OPENXLSX_XLCELLVALUE_H
 
+#include "config.h"
 #include "XLDefinitions.h"
 #include <type_traits>
 #include <string>
@@ -105,7 +106,7 @@ namespace OpenXLSX {
      * cout << "Cell D1: " << D1 << endl;
      * ```
      */
-    class XLCellValue {
+    class OPENXLSX_EXPORT XLCellValue {
         friend class XLCell;
 
     private:

--- a/@library/@openxlsx/interfaces/c++/headers/XLChartsheet.h
+++ b/@library/@openxlsx/interfaces/c++/headers/XLChartsheet.h
@@ -46,6 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCHARTSHEET_H
 #define OPENXLSX_XLCHARTSHEET_H
 
+#include "config.h"
 #include "XLSheet.h"
 
 namespace OpenXLSX {
@@ -53,7 +54,7 @@ namespace OpenXLSX {
         class XLChartsheet;
     } // namespace Impl
 
-    class XLChartsheet : public XLSheet {
+    class OPENXLSX_EXPORT XLChartsheet : public XLSheet {
     public:
 
         /**

--- a/@library/@openxlsx/interfaces/c++/headers/XLColumn.h
+++ b/@library/@openxlsx/interfaces/c++/headers/XLColumn.h
@@ -46,6 +46,8 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCOLUMN_H
 #define OPENXLSX_XLCOLUMN_H
 
+#include "config.h"
+
 namespace OpenXLSX {
     namespace Impl {
         class XLColumn;
@@ -54,7 +56,7 @@ namespace OpenXLSX {
     /**
      * @brief
      */
-    class XLColumn {
+    class OPENXLSX_EXPORT XLColumn {
     public:
 
         /**

--- a/@library/@openxlsx/interfaces/c++/headers/XLDefinitions.h
+++ b/@library/@openxlsx/interfaces/c++/headers/XLDefinitions.h
@@ -47,6 +47,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #define OPENXLSX_XLDEFINITIONS_H
 
 #include <cstdint>
+#include "config.h"
 
 namespace OpenXLSX {
 

--- a/@library/@openxlsx/interfaces/c++/headers/XLDocument.h
+++ b/@library/@openxlsx/interfaces/c++/headers/XLDocument.h
@@ -48,6 +48,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 
 #include <memory>
 
+#include "config.h"
 #include "XLDefinitions.h"
 #include "XLWorkbook.h"
 
@@ -85,7 +86,7 @@ namespace OpenXLSX {
      *
      * @todo Implement a Clone method. Ensure that the source object is not modified in any way, including saving to disk.
      */
-    class XLDocument {
+    class OPENXLSX_EXPORT XLDocument {
     public:
 
         /**

--- a/@library/@openxlsx/interfaces/c++/headers/XLException.h
+++ b/@library/@openxlsx/interfaces/c++/headers/XLException.h
@@ -47,9 +47,10 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #define OPENXLSX_XLEXCEPTION_H
 
 #include <stdexcept>
+#include "config.h"
 
 namespace OpenXLSX {
-    class XLException : public std::runtime_error {
+    class OPENXLSX_EXPORT XLException : public std::runtime_error {
     public:
         inline explicit XLException(const std::string& err)
                 : runtime_error(err) {

--- a/@library/@openxlsx/interfaces/c++/headers/XLRow.h
+++ b/@library/@openxlsx/interfaces/c++/headers/XLRow.h
@@ -46,6 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLROW_H
 #define OPENXLSX_XLROW_H
 
+#include "config.h"
 #include "XLCell.h"
 
 namespace OpenXLSX {
@@ -56,7 +57,7 @@ namespace OpenXLSX {
     /**
      * @brief
      */
-    class XLRow {
+    class OPENXLSX_EXPORT XLRow {
     public:
 
         /**

--- a/@library/@openxlsx/interfaces/c++/headers/XLSheet.h
+++ b/@library/@openxlsx/interfaces/c++/headers/XLSheet.h
@@ -48,6 +48,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 
 #include <string>
 
+#include "config.h"
 #include "XLDefinitions.h"
 
 namespace OpenXLSX {
@@ -58,7 +59,7 @@ namespace OpenXLSX {
     /**
      * @brief
      */
-    class XLSheet {
+    class OPENXLSX_EXPORT XLSheet {
     public:
 
         /**

--- a/@library/@openxlsx/interfaces/c++/headers/XLWorkbook.h
+++ b/@library/@openxlsx/interfaces/c++/headers/XLWorkbook.h
@@ -48,6 +48,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 
 #include <string>
 
+#include "config.h"
 #include "XLSheet.h"
 #include "XLWorksheet.h"
 #include "XLChartsheet.h"
@@ -60,7 +61,7 @@ namespace OpenXLSX {
     /**
      * @brief
      */
-    class XLWorkbook {
+    class OPENXLSX_EXPORT XLWorkbook {
     public:
 
         /**

--- a/@library/@openxlsx/interfaces/c++/headers/XLWorksheet.h
+++ b/@library/@openxlsx/interfaces/c++/headers/XLWorksheet.h
@@ -46,6 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLWORKSHEET_H
 #define OPENXLSX_XLWORKSHEET_H
 
+#include "config.h"
 #include "XLSheet.h"
 #include "XLCellReference.h"
 #include "XLCell.h"
@@ -61,7 +62,7 @@ namespace OpenXLSX {
     /**
      * @brief
      */
-    class XLWorksheet : public XLSheet {
+    class OPENXLSX_EXPORT XLWorksheet : public XLSheet {
     public:
 
         /**


### PR DESCRIPTION
Add config.h header with define OPENXLSX_EXPORT with __declspec directive
for support export symbols in build and import in client code.

This change compile with test and return same results as original code:

test cases:   7 |   4 passed | 3 failed
assertions: 111 | 106 passed | 5 failed