### PR TITLE
Add support for DLL exports in Win32 platforms

### DIFF
--- a/@library/@openxlsx/CMakeLists.txt
+++ b/@library/@openxlsx/CMakeLists.txt
@@ -30,6 +30,16 @@ if(CHARCONV_RESULT)
 endif()
 
 #=======================================================================================================================
+# Enable dllspec if it's Win32 target
+#=======================================================================================================================
+get_target_property(TARGET_TYPE OpenXLSX TYPE)
+if (WIN32 AND (TARGET_TYPE STREQUAL "SHARED_LIBRARY"))
+    set(BUILD_SHARED 1)
+    target_compile_definitions(OpenXLSX PRIVATE "INBUILD")
+endif()
+configure_file(${CMAKE_CURRENT_LIST_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h)
+
+#=======================================================================================================================
 # Set compiler flags
 #=======================================================================================================================
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -191,7 +201,8 @@ target_include_directories(OpenXLSX
         PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/implementation/headers
         PUBLIC
-        ${CMAKE_CURRENT_LIST_DIR}/interfaces/c++/headers)
+        ${CMAKE_CURRENT_LIST_DIR}/interfaces/c++/headers
+        ${CMAKE_CURRENT_BINARY_DIR})
 
 # ===== Set output directories for targets to (staged) installation directory ===== #
 set_target_properties(OpenXLSX PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${OPENXLSX_INSTALLDIR}/lib)
@@ -200,6 +211,7 @@ set_target_properties(OpenXLSX PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${OPENXLSX_IN
 # ===== Copy header files to (staged) install directory ===== #
 file(REMOVE_RECURSE ${OPENXLSX_INSTALLDIR}/include/)
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/interfaces/c++/headers/ DESTINATION ${OPENXLSX_INSTALLDIR}/include/OpenXLSX)
+file(COPY ${CMAKE_CURRENT_BINARY_DIR}/config.h DESTINATION ${OPENXLSX_INSTALLDIR}/include/OpenXLSX)
 
 #=======================================================================================================================
 # Install OpenXLSX Library

--- a/@library/@openxlsx/config.h.cmake
+++ b/@library/@openxlsx/config.h.cmake
@@ -43,89 +43,23 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 
  */
 
-#ifndef OPENXLSX_XLCELL_H
-#define OPENXLSX_XLCELL_H
+#ifndef OPENXLSX_CONFIG_H
+#define OPENXLSX_CONFIG_H
 
-#include "config.h"
-#include "XLDefinitions.h"
-#include "XLCellReference.h"
-#include "XLCellValue.h"
+#cmakedefine BUILD_SHARED @BUILD_SHARED@
 
-namespace OpenXLSX {
-    namespace Impl {
-        class XLCell;
-    } // namespace Impl
+#ifdef WIN32
+  #ifdef BUILD_SHARED
+    #ifdef INBUILD
+      #define OPENXLSX_EXPORT __declspec(dllexport)
+    #else //INBUILD
+      #define OPENXLSX_EXPORT __declspec(dllimport)
+    #endif //INBUILD
+  #else //BUILD_SHARED
+    #define OPENXLSX_EXPORT
+  #endif //BUILD_SHARED
+#else //WIN32
+  #define OPENXLSX_EXPORT
+#endif //WIN32
 
-    /**
-     * @brief
-     */
-    class OPENXLSX_EXPORT XLCell {
-    public:
-
-        /**
-         * @brief
-         * @param cell
-         */
-        explicit XLCell(Impl::XLCell& cell);
-
-        /**
-         * @brief
-         * @param other
-         */
-        XLCell(const XLCell& other) = default;
-
-        /**
-         * @brief
-         * @param other
-         */
-        XLCell(XLCell&& other) = default;
-
-        /**
-         * @brief
-         */
-        virtual ~XLCell() = default;
-
-        /**
-         * @brief
-         * @param other
-         * @return
-         */
-        XLCell& operator=(const XLCell& other) = default;
-
-        /**
-         * @brief
-         * @param other
-         * @return
-         */
-        XLCell& operator=(XLCell&& other) = default;
-
-        /**
-         * @brief
-         * @return
-         */
-        XLCellValue Value();
-
-        /**
-         * @brief
-         * @return
-         */
-        const XLCellValue Value() const;
-
-        /**
-         * @brief
-         * @return
-         */
-        XLValueType ValueType() const;
-
-        /**
-         * @brief
-         * @return
-         */
-        const XLCellReference CellReference() const;
-
-    private:
-        Impl::XLCell* m_cell; /**<  */
-    };
-}  // namespace OpenXLSX
-
-#endif //OPENXLSX_XLCELL_H
+#endif //OPENXLSX_CONFIG_H

--- a/@library/@openxlsx/interfaces/c++/headers/XLCellRange.h
+++ b/@library/@openxlsx/interfaces/c++/headers/XLCellRange.h
@@ -47,6 +47,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #define OPENXLSX_XLCELLRANGE_H
 
 #include <vector>
+#include "config.h"
 #include "XLCell.h"
 
 using XLCellIterator = std::vector<OpenXLSX::XLCell>::iterator;
@@ -60,7 +61,7 @@ namespace OpenXLSX {
     /**
      * @brief
      */
-    class XLCellRange {
+    class OPENXLSX_EXPORT XLCellRange {
     public:
 
         /**
@@ -79,7 +80,7 @@ namespace OpenXLSX {
          * @brief
          * @param other
          */
-        XLCellRange(XLCellRange&& other) = default;
+        XLCellRange(XLCellRange&& other);
 
         /**
          * @brief

--- a/@library/@openxlsx/interfaces/c++/headers/XLCellReference.h
+++ b/@library/@openxlsx/interfaces/c++/headers/XLCellReference.h
@@ -49,6 +49,8 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #include <string>
 #include <memory>
 
+#include "config.h"
+
 namespace OpenXLSX {
     namespace Impl {
         class XLCellReference;
@@ -57,7 +59,7 @@ namespace OpenXLSX {
     /**
      * @brief
      */
-    class XLCellReference {
+    class OPENXLSX_EXPORT XLCellReference {
     public:
 
         /**
@@ -89,7 +91,7 @@ namespace OpenXLSX {
          * @brief
          * @param other
          */
-        XLCellReference(XLCellReference&& other) = default;
+        XLCellReference(XLCellReference&& other);
 
         /**
          * @brief
@@ -108,7 +110,7 @@ namespace OpenXLSX {
          * @param other
          * @return
          */
-        XLCellReference& operator=(XLCellReference&& other) = default;
+        XLCellReference& operator=(XLCellReference&& other);
 
         /**
          * @brief

--- a/@library/@openxlsx/interfaces/c++/headers/XLCellValue.h
+++ b/@library/@openxlsx/interfaces/c++/headers/XLCellValue.h
@@ -46,6 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCELLVALUE_H
 #define OPENXLSX_XLCELLVALUE_H
 
+#include "config.h"
 #include "XLDefinitions.h"
 #include <type_traits>
 #include <string>
@@ -105,7 +106,7 @@ namespace OpenXLSX {
      * cout << "Cell D1: " << D1 << endl;
      * ```
      */
-    class XLCellValue {
+    class OPENXLSX_EXPORT XLCellValue {
         friend class XLCell;
 
     private:

--- a/@library/@openxlsx/interfaces/c++/headers/XLChartsheet.h
+++ b/@library/@openxlsx/interfaces/c++/headers/XLChartsheet.h
@@ -46,6 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCHARTSHEET_H
 #define OPENXLSX_XLCHARTSHEET_H
 
+#include "config.h"
 #include "XLSheet.h"
 
 namespace OpenXLSX {
@@ -53,7 +54,7 @@ namespace OpenXLSX {
         class XLChartsheet;
     } // namespace Impl
 
-    class XLChartsheet : public XLSheet {
+    class OPENXLSX_EXPORT XLChartsheet : public XLSheet {
     public:
 
         /**

--- a/@library/@openxlsx/interfaces/c++/headers/XLColumn.h
+++ b/@library/@openxlsx/interfaces/c++/headers/XLColumn.h
@@ -46,6 +46,8 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCOLUMN_H
 #define OPENXLSX_XLCOLUMN_H
 
+#include "config.h"
+
 namespace OpenXLSX {
     namespace Impl {
         class XLColumn;
@@ -54,7 +56,7 @@ namespace OpenXLSX {
     /**
      * @brief
      */
-    class XLColumn {
+    class OPENXLSX_EXPORT XLColumn {
     public:
 
         /**

--- a/@library/@openxlsx/interfaces/c++/headers/XLDefinitions.h
+++ b/@library/@openxlsx/interfaces/c++/headers/XLDefinitions.h
@@ -47,6 +47,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #define OPENXLSX_XLDEFINITIONS_H
 
 #include <cstdint>
+#include "config.h"
 
 namespace OpenXLSX {
 

--- a/@library/@openxlsx/interfaces/c++/headers/XLDocument.h
+++ b/@library/@openxlsx/interfaces/c++/headers/XLDocument.h
@@ -48,6 +48,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 
 #include <memory>
 
+#include "config.h"
 #include "XLDefinitions.h"
 #include "XLWorkbook.h"
 
@@ -85,7 +86,7 @@ namespace OpenXLSX {
      *
      * @todo Implement a Clone method. Ensure that the source object is not modified in any way, including saving to disk.
      */
-    class XLDocument {
+    class OPENXLSX_EXPORT XLDocument {
     public:
 
         /**

--- a/@library/@openxlsx/interfaces/c++/headers/XLException.h
+++ b/@library/@openxlsx/interfaces/c++/headers/XLException.h
@@ -47,9 +47,10 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #define OPENXLSX_XLEXCEPTION_H
 
 #include <stdexcept>
+#include "config.h"
 
 namespace OpenXLSX {
-    class XLException : public std::runtime_error {
+    class OPENXLSX_EXPORT XLException : public std::runtime_error {
     public:
         inline explicit XLException(const std::string& err)
                 : runtime_error(err) {

--- a/@library/@openxlsx/interfaces/c++/headers/XLRow.h
+++ b/@library/@openxlsx/interfaces/c++/headers/XLRow.h
@@ -46,6 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLROW_H
 #define OPENXLSX_XLROW_H
 
+#include "config.h"
 #include "XLCell.h"
 
 namespace OpenXLSX {
@@ -56,7 +57,7 @@ namespace OpenXLSX {
     /**
      * @brief
      */
-    class XLRow {
+    class OPENXLSX_EXPORT XLRow {
     public:
 
         /**

--- a/@library/@openxlsx/interfaces/c++/headers/XLSheet.h
+++ b/@library/@openxlsx/interfaces/c++/headers/XLSheet.h
@@ -48,6 +48,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 
 #include <string>
 
+#include "config.h"
 #include "XLDefinitions.h"
 
 namespace OpenXLSX {
@@ -58,7 +59,7 @@ namespace OpenXLSX {
     /**
      * @brief
      */
-    class XLSheet {
+    class OPENXLSX_EXPORT XLSheet {
     public:
 
         /**

--- a/@library/@openxlsx/interfaces/c++/headers/XLWorkbook.h
+++ b/@library/@openxlsx/interfaces/c++/headers/XLWorkbook.h
@@ -48,6 +48,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 
 #include <string>
 
+#include "config.h"
 #include "XLSheet.h"
 #include "XLWorksheet.h"
 #include "XLChartsheet.h"
@@ -60,7 +61,7 @@ namespace OpenXLSX {
     /**
      * @brief
      */
-    class XLWorkbook {
+    class OPENXLSX_EXPORT XLWorkbook {
     public:
 
         /**

--- a/@library/@openxlsx/interfaces/c++/headers/XLWorksheet.h
+++ b/@library/@openxlsx/interfaces/c++/headers/XLWorksheet.h
@@ -46,6 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLWORKSHEET_H
 #define OPENXLSX_XLWORKSHEET_H
 
+#include "config.h"
 #include "XLSheet.h"
 #include "XLCellReference.h"
 #include "XLCell.h"
@@ -61,7 +62,7 @@ namespace OpenXLSX {
     /**
      * @brief
      */
-    class XLWorksheet : public XLSheet {
+    class OPENXLSX_EXPORT XLWorksheet : public XLSheet {
     public:
 
         /**

--- a/@library/@openxlsx/interfaces/c++/sources/XLCellRange.cpp
+++ b/@library/@openxlsx/interfaces/c++/sources/XLCellRange.cpp
@@ -20,6 +20,7 @@ XLCellRange::XLCellRange(const XLCellRange& other)
           m_cells(nullptr) {
 
 }
+XLCellRange::XLCellRange(XLCellRange&& other) = default;
 
 XLCellRange::~XLCellRange() = default;
 

--- a/@library/@openxlsx/interfaces/c++/sources/XLCellReference.cpp
+++ b/@library/@openxlsx/interfaces/c++/sources/XLCellReference.cpp
@@ -30,11 +30,15 @@ XLCellReference::XLCellReference(const XLCellReference& other)
 
 }
 
+XLCellReference::XLCellReference(XLCellReference&& other) = default;
+
 XLCellReference& XLCellReference::operator=(const XLCellReference& other) {
 
     *m_cellReference = *other.m_cellReference;
     return *this;
 }
+
+XLCellReference& XLCellReference::operator=(XLCellReference&& other) = default;
 
 XLCellReference::~XLCellReference() = default;
 


### PR DESCRIPTION
Add config.h header with define OPENXLSX_EXPORT with __declspec directive
for support export symbols in build and import in client code.

Also move some default constructors and assignament operators
to .cpp file by avoid incomplete type issues with exported inline
methods.