### PR TITLE
Use object library target for easy integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,10 @@
 # Preamble
 #=======================================================================================================================
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
-project(OpenXLSX)
+project(OpenXLSX
+    VERSION 0.1.0
+    LANGUAGES CXX
+)
 set(OPENXLSX_DEPENDENCIES ${CMAKE_CURRENT_BINARY_DIR}/dependencies)
 set(OPENXLSX_INSTALLDIR ${CMAKE_CURRENT_BINARY_DIR}/install)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
@@ -22,6 +25,7 @@ set(PROJECT_DESCRIPTION "A C++17 library for reading, writing and modifying Exce
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_DEBUG_POSTFIX d)
 
 #=======================================================================================================================
 # Add build options
@@ -43,17 +47,14 @@ endif()
 
 if(${BUILD_SAMPLES})
     add_subdirectory(examples)
-    add_dependencies(Demo1 OpenXLSX)
 endif()
 
 if(${BUILD_TESTS})
     add_subdirectory(tests)
-    add_dependencies(InterfaceTest OpenXLSX)
 endif()
 
 if(${BUILD_BENCHMARKS})
     add_subdirectory(benchmark)
-    add_dependencies(Benchmark OpenXLSX)
 endif()
 
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -2,7 +2,6 @@
 # Define Benchmark target
 #=======================================================================================================================
 add_executable(Benchmark Benchmark.cpp table_printer.h)
-target_link_libraries(Benchmark PUBLIC OpenXLSX)
-target_include_directories(Benchmark PUBLIC ${OPENXLSX_INSTALLDIR}/include)
+target_link_libraries(Benchmark PUBLIC OpenXLSX-static)
 set_target_properties(Benchmark PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${OPENXLSX_INSTALLDIR}/bin)
 #add_custom_command(TARGET Benchmark POST_BUILD COMMAND Benchmark)

--- a/examples/c++/CMakeLists.txt
+++ b/examples/c++/CMakeLists.txt
@@ -2,46 +2,40 @@
 # Define Demo1 target
 #=======================================================================================================================
 add_executable(Demo1 Demo1.cpp)
-target_link_libraries(Demo1 PUBLIC OpenXLSX)
-target_include_directories(Demo1 PUBLIC ${OPENXLSX_INSTALLDIR}/include)
+target_link_libraries(Demo1 PUBLIC OpenXLSX-static)
 set_target_properties(Demo1 PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${OPENXLSX_INSTALLDIR}/bin)
 
 #=======================================================================================================================
 # Define Demo2 target
 #=======================================================================================================================
 add_executable(Demo2 Demo2.cpp)
-target_link_libraries(Demo2 PUBLIC OpenXLSX)
-target_include_directories(Demo2 PUBLIC ${OPENXLSX_INSTALLDIR}/include)
+target_link_libraries(Demo2 PUBLIC OpenXLSX-static)
 set_target_properties(Demo2 PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${OPENXLSX_INSTALLDIR}/bin)
 
 #=======================================================================================================================
 # Define Demo3 target
 #=======================================================================================================================
 add_executable(Demo3 Demo3.cpp)
-target_link_libraries(Demo3 PUBLIC OpenXLSX)
-target_include_directories(Demo3 PUBLIC ${OPENXLSX_INSTALLDIR}/include)
+target_link_libraries(Demo3 PUBLIC OpenXLSX-static)
 set_target_properties(Demo3 PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${OPENXLSX_INSTALLDIR}/bin)
 
 #=======================================================================================================================
 # Define Demo4 target
 #=======================================================================================================================
 add_executable(Demo4 Demo4.cpp)
-target_link_libraries(Demo4 PUBLIC OpenXLSX)
-target_include_directories(Demo4 PUBLIC ${OPENXLSX_INSTALLDIR}/include)
+target_link_libraries(Demo4 PUBLIC OpenXLSX-static)
 set_target_properties(Demo4 PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${OPENXLSX_INSTALLDIR}/bin)
 
 #=======================================================================================================================
 # Define Demo5 target
 #=======================================================================================================================
 add_executable(Demo5 Demo5.cpp)
-target_link_libraries(Demo5 PUBLIC OpenXLSX)
-target_include_directories(Demo5 PUBLIC ${OPENXLSX_INSTALLDIR}/include)
+target_link_libraries(Demo5 PUBLIC OpenXLSX-static)
 set_target_properties(Demo5 PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${OPENXLSX_INSTALLDIR}/bin)
 
 #=======================================================================================================================
 # Define Demo5 target
 #=======================================================================================================================
 add_executable(Demo6 Demo6.cpp)
-target_link_libraries(Demo6 PUBLIC OpenXLSX)
-target_include_directories(Demo6 PUBLIC ${OPENXLSX_INSTALLDIR}/include)
+target_link_libraries(Demo6 PUBLIC OpenXLSX-static)
 set_target_properties(Demo6 PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${OPENXLSX_INSTALLDIR}/bin)

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -4,8 +4,3 @@
 add_subdirectory(pugixml)
 add_subdirectory(zippy)
 add_subdirectory(openxlsx)
-
-#=======================================================================================================================
-# Define Dependencies
-#=======================================================================================================================
-add_dependencies(OpenXLSX PugiXML Zippy)

--- a/library/openxlsx/CMakeLists.txt
+++ b/library/openxlsx/CMakeLists.txt
@@ -197,45 +197,112 @@ target_link_libraries(OpenXLSX-objs
         PugiXML Zippy)
 target_include_directories(OpenXLSX-objs
     PRIVATE
-        ${CMAKE_CURRENT_LIST_DIR}/implementation/headers
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/implementation/headers>
     PUBLIC
-        ${CMAKE_CURRENT_LIST_DIR}/interfaces/c++/headers
-        ${CMAKE_CURRENT_BINARY_DIR})
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/interfaces/c++/headers>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>      # For export header
+)
 target_compile_definitions(OpenXLSX-objs
     PRIVATE
-        OpenXLSX_EXPORTS
+        OpenXLSX_shared_EXPORTS
 )
 
-# ===== Generate static or shared library ===== #
-if (NOT STATIC)
-    add_library(OpenXLSX SHARED "")
-else ()
-    add_library(OpenXLSX STATIC "")
-endif ()
-target_link_libraries(OpenXLSX PUBLIC OpenXLSX-objs)
-add_library(OpenXLSX::OpenXLSX ALIAS OpenXLSX)
+# ===== Generate static library ===== #
+add_library(OpenXLSX-static STATIC "")
+target_link_libraries(OpenXLSX-static
+    PUBLIC
+        OpenXLSX-objs
+)
+target_compile_definitions(OpenXLSX-static
+    PUBLIC
+        OPENXLSX_STATIC_DEFINE
+)
+
+# ===== Generate shared library ===== #
+add_library(OpenXLSX-shared SHARED "")
+target_link_libraries(OpenXLSX-shared
+    PRIVATE
+        OpenXLSX-objs
+)
 
 # ===== Generate shared library export header with compiler-specific keywords ===== #
 include(GenerateExportHeader)
-generate_export_header(OpenXLSX)
-
-# ===== Set output directories for targets to (staged) installation directory ===== #
-set_target_properties(OpenXLSX PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${OPENXLSX_INSTALLDIR}/lib)
-set_target_properties(OpenXLSX PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${OPENXLSX_INSTALLDIR}/lib)
-set_target_properties(OpenXLSX PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${OPENXLSX_INSTALLDIR}/bin)
-
-# ===== Copy header files to (staged) install directory ===== #
-file(REMOVE_RECURSE ${OPENXLSX_INSTALLDIR}/include/)
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/interfaces/c++/headers/ DESTINATION ${OPENXLSX_INSTALLDIR}/include/OpenXLSX)
-file(COPY ${CMAKE_CURRENT_BINARY_DIR}/openxlsx_export.h DESTINATION ${OPENXLSX_INSTALLDIR}/include/OpenXLSX)
+generate_export_header(OpenXLSX-shared
+    BASE_NAME openxlsx
+    EXPORT_FILE_NAME openxlsx_export.h
+)
 
 #=======================================================================================================================
-# Install OpenXLSX Library
+# Install
 #=======================================================================================================================
-#include(GNUInstallDirs)
-#install(TARGETS OpenXLSX
-#        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}${INSTALL_SUFFIX}
-#        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}${INSTALL_SUFFIX}
-#        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-#install(FILES ${OPENXLSX_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/OpenXLSX)
 
+# Some basic stuff we'll need in this section
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+set(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/cmake/openxlsx)
+
+# Install interface headers
+install(
+    FILES ${OPENXLSX_CXX_INTERFACE_HEADERS}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openxlsx/${dir}
+)
+
+# Install export header
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/openxlsx_export.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openxlsx
+)
+
+# Targets
+install(
+    TARGETS
+        OpenXLSX-objs
+        OpenXLSX-static
+        OpenXLSX-shared
+        PugiXML
+        Zippy
+    EXPORT OpenXLSXTargets
+    LIBRARY
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT lib
+    ARCHIVE
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT lib
+    RUNTIME
+        DESTINATION ${CMAKE_INSTALL_BINDIR}
+        COMPONENT bin
+    INCLUDES
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/OpenXLSX
+)
+
+# Package version
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/OpenXLSX/OpenXLSXConfigVersion.cmake"
+    VERSION ${OpenXLSX_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+install(
+    FILES
+    OpenXLSXConfig.cmake
+    "${CMAKE_CURRENT_BINARY_DIR}/OpenXLSX/OpenXLSXConfigVersion.cmake"
+    DESTINATION ${ConfigPackageLocation}
+)
+
+# Package configuration
+configure_file(OpenXLSXConfig.cmake
+    "${CMAKE_CURRENT_BINARY_DIR}/OpenXLSX/OpenXLSXConfig.cmake"
+    COPYONLY
+)
+
+# Package export targets
+export(
+    EXPORT OpenXLSXTargets
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/OpenXLSX/OpenXLSXTargets.cmake"
+    NAMESPACE OpenXLSX::
+)
+install(
+    EXPORT OpenXLSXTargets
+    FILE OpenXLSXTargets.cmake
+    NAMESPACE OpenXLSX::
+    DESTINATION ${ConfigPackageLocation}
+)

--- a/library/openxlsx/CMakeLists.txt
+++ b/library/openxlsx/CMakeLists.txt
@@ -1,12 +1,7 @@
 #=======================================================================================================================
 # Define library targets
 #=======================================================================================================================
-if (NOT STATIC)
-    add_library(OpenXLSX SHARED "")
-else ()
-    add_library(OpenXLSX STATIC "")
-endif ()
-add_library(OpenXLSX::OpenXLSX ALIAS OpenXLSX)
+add_library(OpenXLSX-objs OBJECT "")
 
 #=======================================================================================================================
 # Feature Checks
@@ -29,7 +24,7 @@ check_cxx_source_compiles("
                           }" CHARCONV_RESULT)
 
 if (CHARCONV_RESULT)
-    target_compile_definitions(OpenXLSX PRIVATE CHARCONV_ENABLED)
+    target_compile_definitions(OpenXLSX-objs PRIVATE CHARCONV_ENABLED)
 endif ()
 
 #=======================================================================================================================
@@ -48,57 +43,66 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
         #target_compile_options(OpenXLSX PRIVATE -Wlifetime)
     elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-        target_compile_options(OpenXLSX PRIVATE -Wmisleading-indentation)
-        target_compile_options(OpenXLSX PRIVATE -Wduplicated-cond)
-        target_compile_options(OpenXLSX PRIVATE -Wduplicated-branches)
-        target_compile_options(OpenXLSX PRIVATE -Wlogical-op)
-        target_compile_options(OpenXLSX PRIVATE -Wnull-dereference)
-        target_compile_options(OpenXLSX PRIVATE -Wuseless-cast)
+        target_compile_options(OpenXLSX-objs
+            PRIVATE
+                -Wmisleading-indentation
+                -Wduplicated-cond
+                -Wduplicated-branches
+                -Wlogical-op
+                -Wnull-dereference
+                -Wuseless-cast
+        )
     elseif (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") OR ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU"))
-        target_compile_options(OpenXLSX PRIVATE -Wall)
-        target_compile_options(OpenXLSX PRIVATE -Wextra)
-        target_compile_options(OpenXLSX PRIVATE -Wshadow)
-        target_compile_options(OpenXLSX PRIVATE -Wnon-virtual-dtor)
-        target_compile_options(OpenXLSX PRIVATE -Wold-style-cast)
-        target_compile_options(OpenXLSX PRIVATE -Wcast-align)
-        target_compile_options(OpenXLSX PRIVATE -Wunused)
-        target_compile_options(OpenXLSX PRIVATE -Woverloaded-virtual)
-        target_compile_options(OpenXLSX PRIVATE -Wpedantic)
-        target_compile_options(OpenXLSX PRIVATE -Wconversion)
-        target_compile_options(OpenXLSX PRIVATE -Wsign-conversion)
-        target_compile_options(OpenXLSX PRIVATE -Wdouble-promotion)
-        target_compile_options(OpenXLSX PRIVATE -Wformat=2)
-        target_compile_options(OpenXLSX PRIVATE -Weffc++)
+        target_compile_options(OpenXLSX-objs
+            PRIVATE
+                -Wall
+                -Wextra
+                -Wshadow
+                -Wnon-virtual-dtor
+                -Wold-style-cast
+                -Wcast-align
+                -Wunused
+                -Woverloaded-virtual
+                -Wpedantic
+                -Wconversion
+                -Wsign-conversion
+                -Wdouble-promotion
+                -Wformat=2
+                -Weffc++
+        )
     elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
         # using Intel C++
     elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-        target_compile_options(OpenXLSX PRIVATE /permissive)
-        target_compile_options(OpenXLSX PRIVATE /W4)
-        target_compile_options(OpenXLSX PRIVATE /w14242)
-        target_compile_options(OpenXLSX PRIVATE /w14254)
-        target_compile_options(OpenXLSX PRIVATE /w14263)
-        target_compile_options(OpenXLSX PRIVATE /w14265)
-        target_compile_options(OpenXLSX PRIVATE /w14287)
-        target_compile_options(OpenXLSX PRIVATE /we4289)
-        target_compile_options(OpenXLSX PRIVATE /w14296)
-        target_compile_options(OpenXLSX PRIVATE /w14311)
-        target_compile_options(OpenXLSX PRIVATE /w14545)
-        target_compile_options(OpenXLSX PRIVATE /w14546)
-        target_compile_options(OpenXLSX PRIVATE /w14547)
-        target_compile_options(OpenXLSX PRIVATE /w14549)
-        target_compile_options(OpenXLSX PRIVATE /w14555)
-        target_compile_options(OpenXLSX PRIVATE /w14619)
-        target_compile_options(OpenXLSX PRIVATE /w14640)
-        target_compile_options(OpenXLSX PRIVATE /w14826)
-        target_compile_options(OpenXLSX PRIVATE /w14905)
-        target_compile_options(OpenXLSX PRIVATE /w14906)
-        target_compile_options(OpenXLSX PRIVATE /w14928)
+        target_compile_options(OpenXLSX-objs
+            PRIVATE
+                /permissive
+                /W4
+                /w14242
+                /w14254
+                /w14263
+                /w14265
+                /w14287
+                /we4289
+                /w14296
+                /w14311
+                /w14545
+                /w14546
+                /w14547
+                /w14549
+                /w14555
+                /w14619
+                /w14640
+                /w14826
+                /w14905
+                /w14906
+                /w14928
+        )
     endif ()
 elseif (CMAKE_BUILD_TYPE STREQUAL "Release")
     include(CheckIPOSupported)
     check_ipo_supported(RESULT result OUTPUT output)
     if (result)
-        set_property(TARGET OpenXLSX PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+        set_property(TARGET OpenXLSX-objs PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
     endif ()
 endif ()
 
@@ -184,19 +188,32 @@ set(OPENXLSX_CXX_INTERFACE_SOURCES
 #=======================================================================================================================
 # Build OpenXLSX library
 #=======================================================================================================================
-target_sources(OpenXLSX
-        PRIVATE
+target_sources(OpenXLSX-objs
+    PRIVATE
         ${OPENXLSX_IMPL_SOURCES}
         ${OPENXLSX_CXX_INTERFACE_SOURCES})
-target_link_libraries(OpenXLSX
-        PRIVATE
+target_link_libraries(OpenXLSX-objs
+    PRIVATE
         PugiXML Zippy)
-target_include_directories(OpenXLSX
-        PRIVATE
+target_include_directories(OpenXLSX-objs
+    PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/implementation/headers
-        PUBLIC
+    PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/interfaces/c++/headers
         ${CMAKE_CURRENT_BINARY_DIR})
+target_compile_definitions(OpenXLSX-objs
+    PRIVATE
+        OpenXLSX_EXPORTS
+)
+
+# ===== Generate static or shared library ===== #
+if (NOT STATIC)
+    add_library(OpenXLSX SHARED "")
+else ()
+    add_library(OpenXLSX STATIC "")
+endif ()
+target_link_libraries(OpenXLSX PUBLIC OpenXLSX-objs)
+add_library(OpenXLSX::OpenXLSX ALIAS OpenXLSX)
 
 # ===== Generate shared library export header with compiler-specific keywords ===== #
 include(GenerateExportHeader)

--- a/library/openxlsx/OpenXLSXConfig.cmake
+++ b/library/openxlsx/OpenXLSXConfig.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/OpenXLSXTargets.cmake")

--- a/library/pugixml/CMakeLists.txt
+++ b/library/pugixml/CMakeLists.txt
@@ -3,4 +3,7 @@
 #=======================================================================================================================
 add_library(PugiXML INTERFACE)
 add_library(PugiXML::PugiXML ALIAS PugiXML)
-target_include_directories(PugiXML SYSTEM INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+target_include_directories(PugiXML
+    SYSTEM INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
+)

--- a/library/zippy/CMakeLists.txt
+++ b/library/zippy/CMakeLists.txt
@@ -3,4 +3,7 @@
 #=======================================================================================================================
 add_library(Zippy INTERFACE)
 add_library(Zippy::Zippy ALIAS Zippy)
-target_include_directories(Zippy SYSTEM INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+target_include_directories(Zippy
+    SYSTEM INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
+)

--- a/tests/c++/CMakeLists.txt
+++ b/tests/c++/CMakeLists.txt
@@ -1,13 +1,20 @@
 add_executable(InterfaceTest "")
-target_sources(InterfaceTest PRIVATE
+
+target_sources(InterfaceTest
+    PRIVATE
         Test00_Main.cpp
         Test01_DocumentCreation.cpp
         Test02_DocumentProperties.cpp
         Test03_Workbook.cpp
         Test04-06_Sheet.cpp
         Test07_CellReference.cpp
-        Test08_Cell.cpp)
+        Test08_Cell.cpp
+)
 
-target_link_libraries(InterfaceTest PRIVATE Catch INTERFACE Catch)
-target_link_libraries(InterfaceTest PUBLIC OpenXLSX)
+target_link_libraries(InterfaceTest
+    PRIVATE
+        OpenXLSX-static
+        Catch
+)
+
 #add_custom_command(TARGET InterfaceTest POST_BUILD COMMAND InterfaceTest)


### PR DESCRIPTION
Instead of building either the static or shared library directly, the cmake object library target is used. Either the static or shared library will be built from that which preserves current behavior.

The cmake object library makes it easy to include OpenXLSX as a cmake object library into a parent project which might want to link multiple libraries into either an application or shared library which isn't possible without needing to link the whole archive.