### PR TITLE
Modified CMake option for OpenXLSX-Exports

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -253,7 +253,7 @@ install(
 
 # Install export header
 install(
-        FILES ${CMAKE_CURRENT_BINARY_DIR}/openxlsx_export.h
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/OpenXLSX-Exports.hpp
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openxlsx
 )
 


### PR DESCRIPTION
Closes #64 

This modification was needed in order to proceed with the correct installation of the library, as the filename for the include library changed.