### PR TITLE
Fix branch name for google/benchmark

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -4,7 +4,7 @@
 include(FetchContent)
 FetchContent_Declare(gbench
                      GIT_REPOSITORY https://github.com/google/benchmark.git
-                     GIT_TAG master
+                     GIT_TAG main
                      )
 
 FetchContent_GetProperties(gbench)


### PR DESCRIPTION
The `master` branch for the dependency repo Google/benchmark does not exist anymore and the default branch is now called `main`. This commit fixes the branch name in the `benchmark/CMakeLists.txt` specified by the `GIT_TAG` property of the `FetchContent_Declare` command.

Without this fix, the CMake generation step fails.

```
[1/9] Creating directories for 'gbench-populate'
[1/9] Performing download step (git clone) for 'gbench-populate'
Cloning into 'gbench-src'...
fatal: invalid reference: master
CMake Error at gbench-subbuild/gbench-populate-prefix/tmp/gbench-populate-gitclone.cmake:4
0 (message):
  Failed to checkout tag: 'master'


FAILED: gbench-populate-prefix/src/gbench-populate-stamp/gbench-populate-download 
```