### PR TITLE
Fix cmake install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@
 # Preamble
 #=======================================================================================================================
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+set(OPENXLSX_MAJOR_VERSION 0)
+set(OPENXLSX_MINOR_VERSION 2)
+set(OPENXLSX_MICRO_VERSION 0)
 project(OpenXLSX VERSION 0.2.0 LANGUAGES CXX)
 set(CMAKE_DEBUG_POSTFIX d)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -253,7 +253,18 @@ install(
 
 # Install export header
 install(
-        FILES ${CMAKE_CURRENT_BINARY_DIR}/openxlsx_export.h
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/OpenXLSX-Exports.hpp
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openxlsx
+)
+
+file(GLOB OPENXLSX_HEADER_LIST ${CMAKE_CURRENT_LIST_DIR}/headers/*.hpp)
+install(
+        FILES ${OPENXLSX_HEADER_LIST}
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openxlsx/headers
+)
+
+install(
+        FILES ${CMAKE_CURRENT_LIST_DIR}/OpenXLSX.hpp
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openxlsx
 )
 
@@ -269,6 +280,9 @@ install(
         COMPONENT bin
         INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/OpenXLSX
 )
+
+set_target_properties(OpenXLSX-shared PROPERTIES FOLDER libs VERSION ${OPENXLSX_MAJOR_VERSION}.${OPENXLSX_MINOR_VERSION}.${OPENXLSX_MICRO_VERSION} SOVERSION ${OPENXLSX_MAJOR_VERSION})
+set_target_properties(OpenXLSX-static PROPERTIES FOLDER libs VERSION ${OPENXLSX_MAJOR_VERSION}.${OPENXLSX_MINOR_VERSION}.${OPENXLSX_MICRO_VERSION} SOVERSION ${OPENXLSX_MAJOR_VERSION})
 
 # Package version
 write_basic_package_version_file(


### PR DESCRIPTION
make install appeared to be broken. Fixed it and added version based links to library ensuring that it complies with QA performed by build systems such as Linux Yocto. 