### PR TITLE
XLDateTime correctly rounds seconds in tm()

### DIFF
--- a/OpenXLSX/sources/XLDateTime.cpp
+++ b/OpenXLSX/sources/XLDateTime.cpp
@@ -4,7 +4,7 @@
 
 #include "XLDateTime.hpp"
 #include "XLException.hpp"
-#include <iostream>
+#include <cmath>
 
 namespace {
 
@@ -231,7 +231,7 @@ namespace OpenXLSX
         serial -= (result.tm_min / (24.0 * 60.0));
 
         // ===== Calculate the number of seconds.
-        result.tm_sec = static_cast<int>(serial * 24 * 60 * 60);
+        result.tm_sec = static_cast<int>(lround(serial * 24 * 60 * 60));
 
         return result;
     }

--- a/Tests/testXLDateTime.cpp
+++ b/Tests/testXLDateTime.cpp
@@ -47,6 +47,25 @@ TEST_CASE("XLDateTime Tests", "[XLFormula]")
         REQUIRE(tm.tm_sec == 5);
     }
 
+    SECTION("Constructor (serial number, seconds rounding)")
+    {
+        REQUIRE_THROWS(XLDateTime(0.0));
+
+        const double serial = 6069.000008;
+        XLDateTime dt (serial);
+
+        REQUIRE(dt.serial() == Approx(serial));
+
+        auto tm = dt.tm();
+        REQUIRE(tm.tm_year == 16);
+        REQUIRE(tm.tm_mon == 7);
+        REQUIRE(tm.tm_mday == 12);
+        REQUIRE(tm.tm_wday == 6);
+        REQUIRE(tm.tm_hour == 0);
+        REQUIRE(tm.tm_min == 0);
+        REQUIRE(tm.tm_sec == 1);
+    }
+
     SECTION("Constructor (std::tm object)")
     {
         std::tm tmo;


### PR DESCRIPTION
`XLDateTime::tm()` missed to round the seconds part.
This lead to the following behavior (example numbers, which may not show this behavior):
```
Actual time in cell     parsed time
...
01:23:22                01:23:22
01:23:23                01:23:22
01:23:24                01:23:24
...