### PR TITLE
Add constructor to XLDateTime to accept time_t format

### DIFF
--- a/OpenXLSX/headers/XLDateTime.hpp
+++ b/OpenXLSX/headers/XLDateTime.hpp
@@ -83,6 +83,12 @@ namespace OpenXLSX
         explicit XLDateTime(const std::tm& timepoint);
 
         /**
+         * @brief Constructor taking a unixtime format (seconds since 1/1/1970) as an argument.
+         * @param unixtime A time_t number.
+         */
+        explicit XLDateTime(time_t unixtime);
+
+        /**
          * @brief Copy constructor.
          * @param other Object to be copied.
          */

--- a/OpenXLSX/sources/XLDateTime.cpp
+++ b/OpenXLSX/sources/XLDateTime.cpp
@@ -120,6 +120,15 @@ namespace OpenXLSX
     }
 
     /**
+     * @details Constructor taking a unixtime format (seconds since 1/1/1970) as an argument.
+     */
+    XLDateTime::XLDateTime(time_t unixtime) {
+        // There are 86400 seconds in a day
+        // There are 25569 days between 1/1/1970 and 30/12/1899 (the epoch used by Excel)
+        m_serial = static_cast<double>(unixtime) / 86400 + 25569;
+    }
+
+    /**
      * @details Copy constructor. Default implementation.
      */
     XLDateTime::XLDateTime(const XLDateTime& other) = default;


### PR DESCRIPTION
Unix time format is used in lots of places, including the C++ type `time_t` which records time as number of seconds since 1/1/1970
Excel's date/time format is number of days since 30/12/1899

I added a constructor to XLDateTime to do this conversion without using the tm struct.

Possible minor issue: `time_t` is defined to be UTC but Excel has no knowledge of timezones (or daylight saving) ?