### PR TITLE
Readme clarification issue #124

### DIFF
--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -9,12 +9,16 @@ project(OpenXLSX.Examples)
 #=======================================================================================================================
 add_subdirectory(external/nowide EXCLUDE_FROM_ALL)
 
+#make all the demo statically linked
+set(CMAKE_EXE_LINKER_FLAGS " -static")
+
 #=======================================================================================================================
 # Define Demo1 target
 #=======================================================================================================================
 add_executable(Demo1 Demo1.cpp)
-target_link_libraries(Demo1 PRIVATE OpenXLSX::OpenXLSX)
-
+target_link_libraries(Demo1 PRIVATE -static-libgcc -static-libstdc++ OpenXLSX::OpenXLSX)
+# you can check with cmd `ldd  DeemoN.exe` that 
+# all N exe depend only on msvcrt and kernel dll
 #=======================================================================================================================
 # Define Demo2 target
 #=======================================================================================================================

--- a/README.md
+++ b/README.md
@@ -173,7 +173,10 @@ For example, if you use ninja on MinGW, run
 ninja
 ```
 
-from the build directory to produce the executables in the output folde to produce the executables in the output folder.
+from the build directory to produce the executables in the output folder. Read e.g. [this blog paragraph](https://dmerej.info/blog/post/chuck-norris-part-1-cmake-ninja/#ninja):
+> CMake does not know how to actually perform the build. Instead it generates files that will be used by an other tool.
+> ...
+> And now we use ninja to build and run our executable from the build folder
 
 When built, you can install it using the following command:
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,15 @@ cmake --build . --target OpenXLSX --config Release
 
 You can change the `--target` and `--config` arguments to whatever you wish to use.
 
+For example, if you use ninja on MinGW, run
+
+
+```
+ninja
+```
+
+from the build directory to produce the executables in the output folde to produce the executables in the output folder.
+
 When built, you can install it using the following command:
 
 ```


### PR DESCRIPTION
And static flags for portable demo executables, to move them to another Windows 64-bit target machine, even if there is no msys2 there.