### PR TITLE
Fix compilation error with Visual Studio 2019 or 2022

### DIFF
--- a/OpenXLSX/headers/XLSheet.hpp
+++ b/OpenXLSX/headers/XLSheet.hpp
@@ -137,7 +137,7 @@ namespace OpenXLSX
         XLSheetState visibility() const
         {
             XLQuery query(XLQueryType::QuerySheetVisibility);
-            query.template setParam("sheetID", relationshipID());
+            query.setParam("sheetID", relationshipID());
             auto state  = parentDoc().execQuery(query).template result<std::string>();
             auto result = XLSheetState::Visible;
 
@@ -208,7 +208,7 @@ namespace OpenXLSX
 //            return uint16_t(std::stoi(parentDoc().execQuery(R"({ "query": "QuerySheetIndex", "sheetID": ")" + relationshipID() + "\"}")));
 
             XLQuery query(XLQueryType::QuerySheetIndex);
-            query.template setParam("sheetID", relationshipID());
+            query.setParam("sheetID", relationshipID());
             return uint16_t(std::stoi(parentDoc().execQuery(query).template result<std::string>()));
         }
 


### PR DESCRIPTION
Since commit https://github.com/troldal/OpenXLSX/commit/efff9af403f481d075b8c3eb11b9035539147964
OpenXLSX has compilation error with Visual Studio 2019

error C2059: syntax error: 'template'

see https://github.com/troldal/OpenXLSX/issues/129

This PR fix the compilation error