### PR TITLE
Do not build optional targets when used with `add_subdirectory()`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,18 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/output)
 #=======================================================================================================================
 # Add build options
 #=======================================================================================================================
-option(OPENXLSX_CREATE_DOCS "Build library documentation (requires Doxygen and Graphviz/Dot to be installed)" ON)
-option(OPENXLSX_BUILD_SAMPLES "Build sample programs" ON)
-option(OPENXLSX_BUILD_TESTS "Build and run library tests" ON)
-option(OPENXLSX_BUILD_BENCHMARKS "Build and run library benchmarks" ON)
+if(NOT DEFINED OPENXLSX_MASTER_PROJECT)
+    if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+        set(OPENXLSX_MASTER_PROJECT ON)
+    else()
+        set(OPENXLSX_MASTER_PROJECT OFF)
+    endif()
+endif()
+
+option(OPENXLSX_CREATE_DOCS "Build library documentation (requires Doxygen and Graphviz/Dot to be installed)" ${OPENXLSX_MASTER_PROJECT})
+option(OPENXLSX_BUILD_SAMPLES "Build sample programs" ${OPENXLSX_MASTER_PROJECT})
+option(OPENXLSX_BUILD_TESTS "Build and run library tests" ${OPENXLSX_MASTER_PROJECT})
+option(OPENXLSX_BUILD_BENCHMARKS "Build and run library benchmarks" ${OPENXLSX_MASTER_PROJECT})
 option(OPENXLSX_ENABLE_LIBZIP "Enable using libzip" OFF)
 
 #=======================================================================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ option(OPENXLSX_CREATE_DOCS "Build library documentation (requires Doxygen and G
 option(OPENXLSX_BUILD_SAMPLES "Build sample programs" ${OPENXLSX_MASTER_PROJECT})
 option(OPENXLSX_BUILD_TESTS "Build and run library tests" ${OPENXLSX_MASTER_PROJECT})
 option(OPENXLSX_BUILD_BENCHMARKS "Build and run library benchmarks" ${OPENXLSX_MASTER_PROJECT})
+option(OPENXLSX_ACTIVE_INSTALLATION "Generate instalation processus for make" ${OPENXLSX_MASTER_PROJECT})
 option(OPENXLSX_ENABLE_LIBZIP "Enable using libzip" OFF)
 
 #=======================================================================================================================

--- a/OpenXLSX/CMakeLists.txt
+++ b/OpenXLSX/CMakeLists.txt
@@ -243,80 +243,81 @@ endif ()
 #=======================================================================================================================
 # Install
 #=======================================================================================================================
-# Some basic stuff we'll need in this section
-include(GNUInstallDirs)
-include(CMakePackageConfigHelpers)
-set(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/cmake/OpenXLSX)
+if (OPENXLSX_ACTIVE_INSTALLATION)
+    # Some basic stuff we'll need in this section
+    include(GNUInstallDirs)
+    include(CMakePackageConfigHelpers)
+    set(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/cmake/OpenXLSX)
 
-# Install interface headers
-install(
-        FILES ${OPENXLSX_CXX_INTERFACE_HEADERS}
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/OpenXLSX/${dir}
-)
+    # Install interface headers
+    install(
+            FILES ${OPENXLSX_CXX_INTERFACE_HEADERS}
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/OpenXLSX/${dir}
+    )
 
-# Install export header
-install(
-        FILES ${CMAKE_CURRENT_BINARY_DIR}/OpenXLSX-Exports.hpp
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/OpenXLSX/headers
-)
+    # Install export header
+    install(
+            FILES ${CMAKE_CURRENT_BINARY_DIR}/OpenXLSX-Exports.hpp
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/OpenXLSX/headers
+    )
 
-file(GLOB OPENXLSX_HEADER_LIST ${CMAKE_CURRENT_LIST_DIR}/headers/*.hpp)
-install(
-        FILES ${OPENXLSX_HEADER_LIST}
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/OpenXLSX/headers
-)
+    file(GLOB OPENXLSX_HEADER_LIST ${CMAKE_CURRENT_LIST_DIR}/headers/*.hpp)
+    install(
+            FILES ${OPENXLSX_HEADER_LIST}
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/OpenXLSX/headers
+    )
 
-install(
-        FILES ${CMAKE_CURRENT_LIST_DIR}/OpenXLSX.hpp
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/OpenXLSX
-)
+    install(
+            FILES ${CMAKE_CURRENT_LIST_DIR}/OpenXLSX.hpp
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/OpenXLSX
+    )
 
-# Targets
-install(
-        TARGETS OpenXLSX
-        EXPORT OpenXLSXTargets
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        COMPONENT lib
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        COMPONENT lib
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        COMPONENT bin
-        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/OpenXLSX
-)
+    # Targets
+    install(
+            TARGETS OpenXLSX
+            EXPORT OpenXLSXTargets
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT lib
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT lib
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+            COMPONENT bin
+            INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/OpenXLSX
+    )
 
-set_target_properties(OpenXLSX PROPERTIES FOLDER libs VERSION ${OPENXLSX_MAJOR_VERSION}.${OPENXLSX_MINOR_VERSION}.${OPENXLSX_MICRO_VERSION} SOVERSION ${OPENXLSX_MAJOR_VERSION})
+    set_target_properties(OpenXLSX PROPERTIES FOLDER libs VERSION ${OPENXLSX_MAJOR_VERSION}.${OPENXLSX_MINOR_VERSION}.${OPENXLSX_MICRO_VERSION} SOVERSION ${OPENXLSX_MAJOR_VERSION})
 
-# Package version
-write_basic_package_version_file(
-        "${CMAKE_CURRENT_BINARY_DIR}/OpenXLSX/OpenXLSXConfigVersion.cmake"
-        VERSION ${OpenXLSX_VERSION}
-        COMPATIBILITY AnyNewerVersion
-)
-install(
-        FILES
-        OpenXLSXConfig.cmake
-        "${CMAKE_CURRENT_BINARY_DIR}/OpenXLSX/OpenXLSXConfigVersion.cmake"
-        DESTINATION ${ConfigPackageLocation}
-)
+    # Package version
+    write_basic_package_version_file(
+            "${CMAKE_CURRENT_BINARY_DIR}/OpenXLSX/OpenXLSXConfigVersion.cmake"
+            VERSION ${OpenXLSX_VERSION}
+            COMPATIBILITY AnyNewerVersion
+    )
+    install(
+            FILES
+            OpenXLSXConfig.cmake
+            "${CMAKE_CURRENT_BINARY_DIR}/OpenXLSX/OpenXLSXConfigVersion.cmake"
+            DESTINATION ${ConfigPackageLocation}
+    )
 
-# Package configuration
-configure_file(OpenXLSXConfig.cmake
-        "${CMAKE_CURRENT_BINARY_DIR}/OpenXLSX/OpenXLSXConfig.cmake"
-        COPYONLY
-        )
+    # Package configuration
+    configure_file(OpenXLSXConfig.cmake
+            "${CMAKE_CURRENT_BINARY_DIR}/OpenXLSX/OpenXLSXConfig.cmake"
+            COPYONLY
+            )
 
-# Package export targets
-export(
-        EXPORT OpenXLSXTargets
-        FILE "${CMAKE_CURRENT_BINARY_DIR}/OpenXLSX/OpenXLSXTargets.cmake"
-        NAMESPACE OpenXLSX::
-)
-install(
-        EXPORT OpenXLSXTargets
-        FILE OpenXLSXTargets.cmake
-        NAMESPACE OpenXLSX::
-        DESTINATION ${ConfigPackageLocation}
-)
+    # Package export targets
+    export(
+            EXPORT OpenXLSXTargets
+            FILE "${CMAKE_CURRENT_BINARY_DIR}/OpenXLSX/OpenXLSXTargets.cmake"
+            NAMESPACE OpenXLSX::
+    )
+    install(
+            EXPORT OpenXLSXTargets
+            FILE OpenXLSXTargets.cmake
+            NAMESPACE OpenXLSX::
+            DESTINATION ${ConfigPackageLocation}
+    )
 
-
+endif()
 


### PR DESCRIPTION
This patch disables the build of documentation, samples, tests and benchmarks when used as a library with `add_subdirectory()`.
It changes the default behavior, but the option can still be overridden.

Edit: I also added the same behavior for installation
