### PR TITLE
Explicitely cast to `unsigned short int`

### DIFF
--- a/OpenXLSX/sources/XLSheet.cpp
+++ b/OpenXLSX/sources/XLSheet.cpp
@@ -530,12 +530,12 @@ XLCellReference XLWorksheet::lastCell() const noexcept
  */
 uint16_t XLWorksheet::columnCount() const noexcept
 {
-        std::vector<int16_t> counts;
+        std::vector<uint16_t> counts;
         for (const auto& row : rows()) {
-            counts.emplace_back(row.cellCount());
+            counts.emplace_back(static_cast<uint16_t>(row.cellCount()));
         }
 
-        return std::max(static_cast<uint16_t>(1), static_cast<uint16_t>(*std::max_element(counts.begin(), counts.end())));
+        return std::max(static_cast<uint16_t>(1), *std::max_element(counts.begin(), counts.end()));
 }
 
 /**


### PR DESCRIPTION
This patch allows to compile with conversion warnings (specificely C4242 on MSVC) on, without any issue.