### PR TITLE
convert cell names to cell number and vice versa

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,9 @@
 *cmake-build*/
 build/
 
-# Visual Studio
+# Visual Studio (Code)
 .vs/
+.vscode/
 out/
 
 # other

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # Build Directories
 *cmake-build*/
+build/
 
 # Visual Studio
 .vs/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,32 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "OpenXLSXTests",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/output/OpenXLSXTests",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
+        }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,31 @@
                     "ignoreFailures": true
                 },
                 {
-                    "description": "Set Disassembly Flavor to Intel",
+                    "description":  "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+        {
+            "name": "create template",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/output/createTemplate",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description":  "Set Disassembly Flavor to Intel",
                     "text": "-gdb-set disassembly-flavor intel",
                     "ignoreFailures": true
                 }

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -67,3 +67,8 @@ target_link_libraries(Demo7 PRIVATE OpenXLSX::OpenXLSX)
 add_executable(Demo8 Demo8.cpp)
 target_link_libraries(Demo8 PRIVATE OpenXLSX::OpenXLSX)
 
+#=======================================================================================================================
+# Define createTemplate (Demo9) target
+#=======================================================================================================================
+add_executable(createTemplate createTemplate.cpp)
+target_link_libraries(createTemplate PRIVATE OpenXLSX::OpenXLSX)

--- a/Examples/createTemplate.cpp
+++ b/Examples/createTemplate.cpp
@@ -1,35 +1,26 @@
 /**
- * @file createTemplate.cpp
- * @author Oliver Ofenloch (57812959+ofenloch@users.noreply.github.com)
- * @brief
- * @version 0.1
- * @date 2022-08-03
- *
- * @copyright Copyright (c) 2022
- *
- */
+* @file createTemplate.cpp
+* @author Oliver Ofenloch (57812959+ofenloch@users.noreply.github.com)
+* @brief
+* @version 0.1
+* @date 2022-08-03
+*
+* @copyright Copyright (c) 2022
+*
+*/
+
+#include <iostream>
 
 #include <OpenXLSX.hpp>
-#include <iostream>
 
 int main(int argc, char* argv[])
 {
     int returnValue { 0 };
 
     // OpenXLSX uses
-    //          uint16_t for cell numbers
+    //     uint16_t for cell numbers
     // and
-    //          uint32_t for row numbers
-
-    for (auto cellName : { "A", "E", "Z", "AA", "AB", "AZ", "BA", "BZ", "CA", "CV", "GR" }) {
-        const uint16_t cellNumber = OpenXLSX::XLWorksheet::columnNameToNumber(cellName);
-        std::cout << "column name " << cellName << " is column number " << cellNumber << '\n';
-        const std::string cellName2 = OpenXLSX::XLWorksheet::columnNumberToName(cellNumber);
-        if (cellName2 != cellName) {
-            std::cout << "ERROR: column number " << cellNumber << " is NOT column name " << cellName2 << '\n';
-        }
-    }
-
+    //     uint32_t for row numbers
     const uint32_t nRows { 15 };
     const uint32_t nRowsOffset { 5 };
 
@@ -38,87 +29,114 @@ int main(int argc, char* argv[])
 
     OpenXLSX::XLDocument doc;
     doc.create(fileName);
-    OpenXLSX::XLWorkbook  wbk = doc.workbook();
+    OpenXLSX::XLWorkbook wbk = doc.workbook();
     OpenXLSX::XLWorksheet wks = wbk.worksheet("Sheet1");
 
-    // just for testing:
-    std::vector<uint16_t> numbers;
-    std::vector<std::string> names;
-    for (uint16_t i = 1; i <= 1024; i++) {
-        numbers.push_back(i);
-        names.push_back(OpenXLSX::XLWorksheet::columnNumberToName(i));
-    }
-    wks.row(1).values() = numbers;
-    wks.row(2).values() = names;
+    // // just for testing:
+    // std::vector<uint16_t> numbers;
+    // std::vector<std::string> names;
+    // for (uint16_t i = 1; i <= 1024; i++) {
+    //     numbers.push_back(i);
+    //     names.push_back(OpenXLSX::XLWorksheet::columnNumberToName(i));
+    // }
+    // wks.row(1).values() = numbers;
+    // wks.row(2).values() = names;
 
     for (uint32_t iLogicalRow = 1; iLogicalRow <= nRows; iLogicalRow++) {
         const std::string siLogicalRow { std::to_string(iLogicalRow) };
-        const uint32_t    iRealRow = nRowsOffset + iLogicalRow;
+        const uint32_t iRealRow = nRowsOffset + iLogicalRow;
         const std::string siRealRow { std::to_string(iRealRow) };
-
-        std::vector<std::string> cellContents;
-
-        // cell A:
+        std::vector<std::string> cellContents;        // cell A:
+        cellContents.push_back(std::string("f(prod_name_" + siLogicalRow + ")"));
+        // cell B:
         cellContents.push_back(std::string("f(prod_massflow_" + siLogicalRow + ")"));
-        // cell B:
-        cellContents.push_back(std::string("f(prod_temperature_" + siLogicalRow + ")"));
         // cell C:
-        cellContents.push_back(std::string("f(prod_pressure_" + siLogicalRow + ")"));
+        cellContents.push_back(std::string("f(prod_temperature_" + siLogicalRow + ")"));
         // cell D:
-        cellContents.push_back(std::string("f(prod_density_" + siLogicalRow + ")"));
+        cellContents.push_back(std::string("f(prod_pressure_" + siLogicalRow + ")"));
         // cell E:
-        cellContents.push_back(std::string("f(prod_viscosity_" + siLogicalRow + ")"));
+        cellContents.push_back(std::string("f(prod_density_" + siLogicalRow + ")"));
         // cell F:
-        cellContents.push_back(std::string("=A" + siRealRow + " / D" + siRealRow));
-        // cell G (empty):
-        cellContents.push_back(std::string(""));
-        // cell H (empty):
-        cellContents.push_back(std::string(""));
+        cellContents.push_back(std::string("f(prod_viscosity_" + siLogicalRow + ")"));
+        // cell G:
+        cellContents.push_back(std::string("f(prod_volumeflow_" + siLogicalRow + ")"));
+        // cell H:
+        cellContents.push_back(std::string("f(prod_nominal_diameter" + siLogicalRow + ")"));
         // cell I:
+        cellContents.push_back(std::string("f(prod_length" + siLogicalRow + ")"));
+        // cell J:
+        cellContents.push_back(std::string("f(prod_velocity_" + siLogicalRow + ")"));
+        // cell K:
         cellContents.push_back(std::string("f(prod_reynolds_" + siLogicalRow + ")"));
+        // cell L:
+        cellContents.push_back(std::string("f(prod_roughness_" + siLogicalRow + ")"));
+        // cell M:
+        // cellContents.push_back(std::string("f(prod_initial_value_" + siLogicalRow + ")"));
+        // original sheet uses this:
+        cellContents.push_back(std::string("=N" + siRealRow + ""));
+        // cell N:
+        // cellContents.push_back(std::string("=WENN(K11>2300;1/(2*(LOG(2,51/K11/(M11)^0,5+L11/H11/3,71)))^2;64/K11)"));
+        cellContents.push_back(std::string("=WENN(K" + siRealRow + ">2300;1/(2*(LOG(2.51/K" + siRealRow + "/(M" + siRealRow + ")^0.5+L" + siRealRow + "/H" + siRealRow + "/3.71)))^2;64/K" + siRealRow + ")"));
+
         wks.row(iRealRow).values() = cellContents;
 
-        // convert formula string to real formula:
-        const std::string cellName   = "F" + siRealRow;
-        const std::string sFormula   = wks.cell(cellName).value();
-        wks.cell(cellName).formula() = sFormula;
+        // Excel does not like the reuslt of this:
+        //////////////////////////////////////////
+        // // convert formula string to real formula:
+        // const std::string cellName = "M" + siRealRow;
+        // const std::string sFormula = wks.cell(cellName).value();
+        // OpenXLSX::XLFormula xlFormula(sFormula);
+        // wks.cell(cellName).value() = "";
+        // wks.cell(cellName).formula() = xlFormula;
     }
 
     for (uint32_t iLogicalRow = 1; iLogicalRow <= nRows; iLogicalRow++) {
         const std::string siLogicalRow { std::to_string(iLogicalRow) };
-        const uint32_t    iRealRow = nRowsOffset + nRows + nRowsOffset + iLogicalRow;
+        const uint32_t iRealRow = nRowsOffset + nRows + nRowsOffset + iLogicalRow;
         const std::string siRealRow { std::to_string(iRealRow) };
-
         std::vector<std::string> cellContents;
-
         // cell A:
-        cellContents.push_back(std::string("f(vap_massflow_" + siLogicalRow + ")"));
+        cellContents.push_back(std::string("f(vap_name_" + siLogicalRow + ")"));
         // cell B:
-        cellContents.push_back(std::string("f(vap_temperature_" + siLogicalRow + ")"));
+        cellContents.push_back(std::string("f(vap_massflow_" + siLogicalRow + ")"));
         // cell C:
-        cellContents.push_back(std::string("f(vap_pressure_" + siLogicalRow + ")"));
+        cellContents.push_back(std::string("f(vap_temperature_" + siLogicalRow + ")"));
         // cell D:
-        cellContents.push_back(std::string("f(vap_density_" + siLogicalRow + ")"));
+        cellContents.push_back(std::string("f(vap_pressure_" + siLogicalRow + ")"));
         // cell E:
+        cellContents.push_back(std::string("f(vap_density_" + siLogicalRow + ")"));
+        // cell F:
         cellContents.push_back(std::string("f(vap_viscosity_" + siLogicalRow + ")"));
-        // cell F (empty):
-        cellContents.push_back(std::string(""));
         // cell G:
-        cellContents.push_back(std::string("=A" + siRealRow + " * B" + siRealRow));
-        // cell H (empty):
-        cellContents.push_back(std::string(""));
+        cellContents.push_back(std::string("f(vap_volumeflow_" + siLogicalRow + ")"));
+        // cell H:
+        cellContents.push_back(std::string("f(vap_nominal_diameter_" + siLogicalRow + ")"));
         // cell I:
+        cellContents.push_back(std::string("f(vap_length" + siLogicalRow + ")"));
+        // cell J:
+        cellContents.push_back(std::string("f(vap_velocity_" + siLogicalRow + ")"));
+        // cell K:
         cellContents.push_back(std::string("f(vap_reynolds_" + siLogicalRow + ")"));
-        wks.row(iRealRow).values() = cellContents;
+        // cell L:
+        cellContents.push_back(std::string("f(vap_roughness_" + siLogicalRow + ")"));
+        // cell M:
+        cellContents.push_back(std::string("f(vap_initial_value_" + siLogicalRow + ")"));
+        // original sheet uses cellContents.push_back(std::string("=N" + siLogicalRow + ""));
+        // cell N:
+        // cellContents.push_back(std::string("=WENN(K11>2300;1/(2*(LOG(2,51/K11/(M11)^0,5+L11/H11/3,71)))^2;64/K11)"));
+        cellContents.push_back(std::string("=WENN(K" + siRealRow + ">2300;1/(2*(LOG(2.51/K" + siRealRow + "/(M" + siRealRow + ")^0.5+L" + siRealRow + "/H" + siRealRow + "/3.71)))^2;64/K" + siRealRow + ")"));
 
-        // convert formula string to real formula:
-        const std::string cellName   = "G" + siRealRow;
-        const std::string sFormula   = wks.cell(cellName).value();
-        wks.cell(cellName).formula() = sFormula;
+
+        wks.row(iRealRow).values() = cellContents;
+        // // convert formula string to real formula:
+        // const std::string cellName = "G" + siRealRow;
+        // const std::string sFormula = wks.cell(cellName).value();
+        // wks.cell(cellName).formula() = sFormula;
     }
+    // wks.setName("Leitungsliste");
 
     // Saving a large spreadsheet can take a while...
-    std::cout << "Saving spreadsheet as " << fileName << " ..." << std::endl;
+    std::cout << "Saving XLDocument as " << fileName << " ..." << std::endl;
     doc.save();
     doc.close();
     return returnValue;

--- a/Examples/createTemplate.cpp
+++ b/Examples/createTemplate.cpp
@@ -1,0 +1,125 @@
+/**
+ * @file createTemplate.cpp
+ * @author Oliver Ofenloch (57812959+ofenloch@users.noreply.github.com)
+ * @brief
+ * @version 0.1
+ * @date 2022-08-03
+ *
+ * @copyright Copyright (c) 2022
+ *
+ */
+
+#include <OpenXLSX.hpp>
+#include <iostream>
+
+int main(int argc, char* argv[])
+{
+    int returnValue { 0 };
+
+    // OpenXLSX uses
+    //          uint16_t for cell numbers
+    // and
+    //          uint32_t for row numbers
+
+    for (auto cellName : { "A", "E", "Z", "AA", "AB", "AZ", "BA", "BZ", "CA", "CV", "GR" }) {
+        const uint16_t cellNumber = OpenXLSX::XLWorksheet::columnNameToNumber(cellName);
+        std::cout << "column name " << cellName << " is column number " << cellNumber << '\n';
+        const std::string cellName2 = OpenXLSX::XLWorksheet::columnNumberToName(cellNumber);
+        if (cellName2 != cellName) {
+            std::cout << "ERROR: column number " << cellNumber << " is NOT column name " << cellName2 << '\n';
+        }
+    }
+
+    const uint32_t nRows { 15 };
+    const uint32_t nRowsOffset { 5 };
+
+    const std::string fileName { "template.xlsx" };
+    std::remove(fileName.c_str());
+
+    OpenXLSX::XLDocument doc;
+    doc.create(fileName);
+    OpenXLSX::XLWorkbook  wbk = doc.workbook();
+    OpenXLSX::XLWorksheet wks = wbk.worksheet("Sheet1");
+
+    // just for testing:
+    std::vector<uint16_t> numbers;
+    std::vector<std::string> names;
+    for (uint16_t i = 1; i <= 1024; i++) {
+        numbers.push_back(i);
+        names.push_back(OpenXLSX::XLWorksheet::columnNumberToName(i));
+    }
+    wks.row(1).values() = numbers;
+    wks.row(2).values() = names;
+
+    for (uint32_t iLogicalRow = 1; iLogicalRow <= nRows; iLogicalRow++) {
+        const std::string siLogicalRow { std::to_string(iLogicalRow) };
+        const uint32_t    iRealRow = nRowsOffset + iLogicalRow;
+        const std::string siRealRow { std::to_string(iRealRow) };
+
+        std::vector<std::string> cellContents;
+
+        // cell A:
+        cellContents.push_back(std::string("f(prod_massflow_" + siLogicalRow + ")"));
+        // cell B:
+        cellContents.push_back(std::string("f(prod_temperature_" + siLogicalRow + ")"));
+        // cell C:
+        cellContents.push_back(std::string("f(prod_pressure_" + siLogicalRow + ")"));
+        // cell D:
+        cellContents.push_back(std::string("f(prod_density_" + siLogicalRow + ")"));
+        // cell E:
+        cellContents.push_back(std::string("f(prod_viscosity_" + siLogicalRow + ")"));
+        // cell F:
+        cellContents.push_back(std::string("=A" + siRealRow + " / D" + siRealRow));
+        // cell G (empty):
+        cellContents.push_back(std::string(""));
+        // cell H (empty):
+        cellContents.push_back(std::string(""));
+        // cell I:
+        cellContents.push_back(std::string("f(prod_reynolds_" + siLogicalRow + ")"));
+        wks.row(iRealRow).values() = cellContents;
+
+        // convert formula string to real formula:
+        const std::string cellName   = "F" + siRealRow;
+        const std::string sFormula   = wks.cell(cellName).value();
+        wks.cell(cellName).formula() = sFormula;
+    }
+
+    for (uint32_t iLogicalRow = 1; iLogicalRow <= nRows; iLogicalRow++) {
+        const std::string siLogicalRow { std::to_string(iLogicalRow) };
+        const uint32_t    iRealRow = nRowsOffset + nRows + nRowsOffset + iLogicalRow;
+        const std::string siRealRow { std::to_string(iRealRow) };
+
+        std::vector<std::string> cellContents;
+
+        // cell A:
+        cellContents.push_back(std::string("f(vap_massflow_" + siLogicalRow + ")"));
+        // cell B:
+        cellContents.push_back(std::string("f(vap_temperature_" + siLogicalRow + ")"));
+        // cell C:
+        cellContents.push_back(std::string("f(vap_pressure_" + siLogicalRow + ")"));
+        // cell D:
+        cellContents.push_back(std::string("f(vap_density_" + siLogicalRow + ")"));
+        // cell E:
+        cellContents.push_back(std::string("f(vap_viscosity_" + siLogicalRow + ")"));
+        // cell F (empty):
+        cellContents.push_back(std::string(""));
+        // cell G:
+        cellContents.push_back(std::string("=A" + siRealRow + " * B" + siRealRow));
+        // cell H (empty):
+        cellContents.push_back(std::string(""));
+        // cell I:
+        cellContents.push_back(std::string("f(vap_reynolds_" + siLogicalRow + ")"));
+        wks.row(iRealRow).values() = cellContents;
+
+        // convert formula string to real formula:
+        const std::string cellName   = "G" + siRealRow;
+        const std::string sFormula   = wks.cell(cellName).value();
+        wks.cell(cellName).formula() = sFormula;
+    }
+
+    // Saving a large spreadsheet can take a while...
+    std::cout << "Saving spreadsheet as " << fileName << " ..." << std::endl;
+    doc.save();
+    doc.close();
+    return returnValue;
+}

--- a/OpenXLSX/headers/XLSheet.hpp
+++ b/OpenXLSX/headers/XLSheet.hpp
@@ -51,6 +51,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #pragma warning(disable : 4275)
 
 // ===== External Includes ===== //
+#include <algorithm>
 #include <type_traits>
 #include <variant>
 #include <vector>
@@ -294,6 +295,58 @@ namespace OpenXLSX
                                         .setParam("sheetID", relationshipID())
                                         .setParam("cloneName", newName));
         }
+
+        /**
+         * @brief convert a column name (e.g. "AY") to a column number (51 in this case)
+         * 
+         * @param columName the column's name (e.g. "AY")
+         * @return uint16_t the corresponding column nuber
+         * @details This method works with upper and lower case column names.
+         */
+        static uint16_t columnNameToNumber(const std::string& columName)
+        {
+            std::string s { columName };
+            // convert to upper case (see https://stackoverflow.com/questions/313970/how-to-convert-an-instance-of-stdstring-to-lower-case)
+            std::transform(s.begin(), s.end(), s.begin(),
+                        [](unsigned char c){ return std::toupper(c); });
+            uint16_t    result = 0;
+            // loop for iterating each alphabet
+            for (uint16_t i = 0; i < s.length(); i++) {
+                // multiplying by 26 updating result
+                // process similar to a conversion with base 26 system
+                result *= 26;
+                result += s[i] - 'A' + 1;
+            }
+            // returning the answer after conversion
+            return result;
+        }
+
+        /**
+         * @brief convert a column's numer (e.g. 702) to a column name ("ZZ" in this case)
+         * 
+         * @param columNumber the column's number (e.g. 702)
+         * @return std::string the correspondig clumn name
+         * @details This method always returns an upper case column name.
+         */
+        static std::string columnNumberToName(const uint16_t& columNumber)
+        {
+            std::string str = "";
+            uint16_t    n { columNumber };
+            while (n) {
+                int rem = n % 26;
+                if (rem == 0) {
+                    str += 'Z';
+                    n = (n / 26) - 1;
+                }
+                else {
+                    str += (rem - 1) + 'A';
+                    n = n / 26;
+                }
+            }
+            reverse(str.begin(), str.begin() + str.length());
+            return str;
+        }
+
     };
 
     /**

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -13,7 +13,7 @@ target_include_directories(Catch SYSTEM INTERFACE $<BUILD_INTERFACE:${CMAKE_CURR
 #=======================================================================================================================
 # Define TEST target
 #=======================================================================================================================
-add_executable(OpenXLSXTests EXCLUDE_FROM_ALL "")
+add_executable(OpenXLSXTests)
 target_sources(OpenXLSXTests
         PRIVATE
         main.cpp
@@ -28,6 +28,7 @@ target_sources(OpenXLSXTests
         testXLFormula.cpp
         testXLRow.cpp
         testXLSheet.cpp
+        testCellNameNumber.cpp
         )
 
 target_link_libraries(OpenXLSXTests

--- a/Tests/main.cpp
+++ b/Tests/main.cpp
@@ -11,17 +11,23 @@
 #define CATCH_CONFIG_RUNNER
 
 #include <catch.hpp>
+#include <filesystem>
 #include <OpenXLSX.hpp>
 #include <cstdio>
 
 using namespace OpenXLSX;
 
-void PrepareDocument(std::string name)
+void PrepareDocument(const std::string& name)
 {
+    // delete the document/file before creating it:
+    std::filesystem::path fileName{name};
+    std::filesystem::remove(fileName);
+    // create the document:
     XLDocument doc;
-    std::remove(name.c_str());
-    doc.create(name);
+    doc.create(fileName);
+    // save the document to the given file;
     doc.save();
+    // close the document:
     doc.close();
 }
 

--- a/Tests/testCellNameNumber.cpp
+++ b/Tests/testCellNameNumber.cpp
@@ -1,0 +1,86 @@
+/**
+ * @file testCellNameNumber.cpp
+ * @author Oliver Ofenloch (57812959+ofenloch@users.noreply.github.com)
+ * @brief
+ * @version 0.1
+ * @date 2022-08-03
+ *
+ * @copyright Copyright (c) 2022
+ *
+ */
+
+#include <OpenXLSX.hpp>
+#include <catch.hpp>
+#include <fstream>
+
+TEST_CASE("Cell Name & Number Tests", "[CellNameNumberConversion]")
+{
+    SECTION("Consistency Test with Selected Values")
+    {
+        std::multimap<uint16_t, std::string> sanctionedValues;
+        sanctionedValues.insert(std::pair(1, "A"));
+        sanctionedValues.insert(std::pair(1, "a"));
+        sanctionedValues.insert(std::pair(2, "B"));
+        sanctionedValues.insert(std::pair(26, "Z"));
+        sanctionedValues.insert(std::pair(27, "AA"));
+        sanctionedValues.insert(std::pair(28, "AB"));
+        sanctionedValues.insert(std::pair(52, "AZ"));
+        sanctionedValues.insert(std::pair(53, "BA"));
+        sanctionedValues.insert(std::pair(129, "DY"));
+        sanctionedValues.insert(std::pair(130, "DZ"));
+        sanctionedValues.insert(std::pair(131, "EA"));
+        sanctionedValues.insert(std::pair(132, "EB"));
+        sanctionedValues.insert(std::pair(702, "ZZ"));
+        sanctionedValues.insert(std::pair(703, "AAA"));
+        sanctionedValues.insert(std::pair(704, "AAB"));
+        sanctionedValues.insert(std::pair(728, "AAZ"));
+        sanctionedValues.insert(std::pair(729, "ABA"));
+        sanctionedValues.insert(std::pair(1023, "AMI"));
+        sanctionedValues.insert(std::pair(1023, "ami"));
+        sanctionedValues.insert(std::pair(1024, "AMJ"));
+        sanctionedValues.insert(std::pair(1024, "amj"));
+        for (auto column : sanctionedValues) {
+            const uint16_t    columnNumberOrig = column.first;
+            const std::string columnNameOrig   = column.second;
+            const uint16_t    columnNumberNew  = OpenXLSX::XLWorksheet::columnNameToNumber(columnNameOrig);
+            std::string       columnNameNew    = OpenXLSX::XLWorksheet::columnNumberToName(columnNumberOrig);
+
+            std::string columnNameOrigUpper   = column.second;
+            // convert columnNameNew to upper case (see
+            // https://stackoverflow.com/questions/313970/how-to-convert-an-instance-of-stdstring-to-lower-case)
+            std::transform(columnNameOrigUpper.begin(), columnNameOrigUpper.end(), columnNameOrigUpper.begin(), [](unsigned char c) {
+                return std::toupper(c);
+            });
+
+            REQUIRE(columnNameNew == columnNameOrigUpper);
+            REQUIRE(columnNumberNew == columnNumberOrig);
+        }
+    }
+
+    SECTION("Number To Name Conversion")
+    {
+        for (auto cellNumber : { 1, 5, 25, 26, 27, 52, 53, 54, 100, 200, 512, 1023, 1024, 1025 }) {
+            const std::string cellName    = OpenXLSX::XLWorksheet::columnNumberToName(cellNumber);
+            const uint16_t    cellNumber2 = OpenXLSX::XLWorksheet::columnNameToNumber(cellName);
+            REQUIRE(cellNumber2 == cellNumber);
+        }
+    }
+
+    SECTION("Name To Number Conversion")
+    {
+        for (auto cellName : { "A", "E", "Z", "AA", "AB", "AZ", "BA", "BZ", "CA", "CV", "GR", "ZA", "AMI", "AMJ" }) {
+            const uint16_t    cellNumber = OpenXLSX::XLWorksheet::columnNameToNumber(cellName);
+            const std::string cellName2  = OpenXLSX::XLWorksheet::columnNumberToName(cellNumber);
+            REQUIRE(cellName2 == cellName);
+        }
+    }
+
+    SECTION("Number To Name Conversion")
+    {
+        for (auto cellNumber : { 1, 5, 25, 26, 27, 52, 53, 54, 100, 200, 512, 1023, 1024, 1025 }) {
+            const std::string cellName    = OpenXLSX::XLWorksheet::columnNumberToName(cellNumber);
+            const uint16_t    cellNumber2 = OpenXLSX::XLWorksheet::columnNameToNumber(cellName);
+            REQUIRE(cellNumber2 == cellNumber);
+        }
+    }
+}

--- a/Tests/testXLCell.cpp
+++ b/Tests/testXLCell.cpp
@@ -4,6 +4,7 @@
 
 #include <OpenXLSX.hpp>
 #include <catch.hpp>
+#include <filesystem>
 #include <fstream>
 
 using namespace OpenXLSX;
@@ -32,8 +33,10 @@ TEST_CASE("XLCell Tests", "[XLCell]")
 
     SECTION("Create from worksheet")
     {
+        std::filesystem::path fileName{"./testXLCell.xlsx"};
+        std::filesystem::remove(fileName);
         XLDocument doc;
-        doc.create("./testXLCell.xlsx");
+        doc.create(fileName);
         XLWorksheet wks = doc.workbook().sheet(1);
         auto cell = wks.cell("A1");
         cell.value() = 42;
@@ -47,8 +50,10 @@ TEST_CASE("XLCell Tests", "[XLCell]")
 
     SECTION("Copy constructor")
     {
+        std::filesystem::path fileName{"./testXLCell.xlsx"};
+        std::filesystem::remove(fileName);
         XLDocument doc;
-        doc.create("./testXLCell.xlsx");
+        doc.create(fileName);
         XLWorksheet wks = doc.workbook().sheet(1);
         auto cell = wks.cell("A1");
         cell.value() = 42;
@@ -64,8 +69,10 @@ TEST_CASE("XLCell Tests", "[XLCell]")
 
     SECTION("Move constructor")
     {
+        std::filesystem::path fileName{"./testXLCell.xlsx"};
+        std::filesystem::remove(fileName);
         XLDocument doc;
-        doc.create("./testXLCell.xlsx");
+        doc.create(fileName);
         XLWorksheet wks = doc.workbook().sheet(1);
         auto cell = wks.cell("A1");
         cell.value() = 42;
@@ -81,8 +88,10 @@ TEST_CASE("XLCell Tests", "[XLCell]")
 
     SECTION("Copy assignment operator")
     {
+        std::filesystem::path fileName{"./testXLCell.xlsx"};
+        std::filesystem::remove(fileName);
         XLDocument doc;
-        doc.create("./testXLCell.xlsx");
+        doc.create(fileName);
         XLWorksheet wks = doc.workbook().sheet(1);
         auto cell = wks.cell("A1");
         cell.value() = 42;
@@ -99,8 +108,10 @@ TEST_CASE("XLCell Tests", "[XLCell]")
 
     SECTION("Move assignment operator")
     {
+        std::filesystem::path fileName{"./testXLCell.xlsx"};
+        std::filesystem::remove(fileName);
         XLDocument doc;
-        doc.create("./testXLCell.xlsx");
+        doc.create(fileName);
         XLWorksheet wks = doc.workbook().sheet(1);
         auto cell = wks.cell("A1");
         cell.value() = 42;
@@ -119,8 +130,10 @@ TEST_CASE("XLCell Tests", "[XLCell]")
 
     SECTION("Setters and Getters")
     {
+        std::filesystem::path fileName{"./testXLCell.xlsx"};
+        std::filesystem::remove(fileName);
         XLDocument doc;
-        doc.create("./testXLCell.xlsx");
+        doc.create(fileName);
         XLWorksheet wks = doc.workbook().sheet(1);
         auto cell = wks.cell("A1");
         cell.formula().set("=1+1");
@@ -140,8 +153,10 @@ TEST_CASE("XLCell Tests", "[XLCell]")
 
     SECTION("Relational operators")
     {
+        std::filesystem::path fileName{"./testXLCell.xlsx"};
+        std::filesystem::remove(fileName);
         auto doc = XLDocument();
-        doc.create("./testXLCell.xlsx");
+        doc.create(fileName);
         auto wks = doc.workbook().worksheet("Sheet1");
 
         auto cell1 = wks.cell("B2");
@@ -156,8 +171,10 @@ TEST_CASE("XLCell Tests", "[XLCell]")
 
     SECTION("Offset function")
     {
+        std::filesystem::path fileName{"./testXLCell.xlsx"};
+        std::filesystem::remove(fileName);
         auto doc = XLDocument();
-        doc.create("./testXLCell.xlsx");
+        doc.create(fileName);
         auto wks = doc.workbook().worksheet("Sheet1");
 
         auto cell1 = wks.cell("B2");

--- a/Tests/testXLDocument.cpp
+++ b/Tests/testXLDocument.cpp
@@ -15,7 +15,7 @@ using namespace OpenXLSX;
 TEST_CASE("XLDocument Tests", "[XLDocument]")
 {
     std::string file    = "./testXLDocument.xlsx";
-    std::string newfile = "./TestDocumentCreationNew.xlsx";
+    std::string newfile = "./testXLDocumentCopy.xlsx";
 
     /**
      * @test
@@ -106,6 +106,7 @@ TEST_CASE("XLDocument Tests", "[XLDocument]")
     //    SECTION("Section 01F: Copy construction")
     //    {
     //        XLDocument doc(file);
+    // @note Copy constructor explicitly deleted.
     //        XLDocument copy = doc;
     //
     //        REQUIRE(copy.name() == doc.name());
@@ -120,6 +121,7 @@ TEST_CASE("XLDocument Tests", "[XLDocument]")
     //    {
     //        XLDocument doc(file);
     //        XLDocument copy;
+    // @note Copy constructor explicitly deleted.
     //        copy = doc;
     //
     //        REQUIRE(copy.name() == doc.name());
@@ -133,6 +135,7 @@ TEST_CASE("XLDocument Tests", "[XLDocument]")
     //    SECTION("Section 01H: Move construction")
     //    {
     //        XLDocument doc(file);
+    // @note Copy constructor explicitly deleted.
     //        XLDocument copy = std::move(doc);
     //
     //        REQUIRE(copy.name() == file);

--- a/Tests/testXLDocument.cpp
+++ b/Tests/testXLDocument.cpp
@@ -28,75 +28,75 @@ TEST_CASE("XLDocument Tests", "[XLDocument]")
         REQUIRE_FALSE(doc);
     }
 
-    //    /**
-    //     * @test Create new document using the CreateDocument method.
-    //     *
-    //     * @details Creates an empty document and creates the excel file using the CreateDocument() member function.
-    //     * Success is tested by checking if the file have been created on disk and that the DocumentName member function
-    //     * returns the correct file name.
-    //     */
-    //    SECTION("Section 01A: Create new using CreateDocument()")
-    //    {
-    //        XLDocument doc;
-    //        doc.create(file);
-    //        std::ifstream f(file);
-    //        REQUIRE(f.good());
-    //        REQUIRE(doc.name() == file);
-    //    }
-    //
-    //    /**
-    //     * @brief Open an existing document using the constructor.
-    //     *
-    //     * @details Opens an existing document by passing the file name to the constructor.
-    //     * Success is tested by checking that the DocumentName member function returns the correct file name.
-    //     */
-    //    SECTION("Section 01B: Open existing using Constructor")
-    //    {
-    //        XLDocument doc(file);
-    //        REQUIRE(doc.name() == file);
-    //    }
-    //
-    //    /**
-    //     * @brief
-    //     *
-    //     * @details
-    //     */
-    //    SECTION("Section 01C: Open existing using openDocument()")
-    //    {
-    //        XLDocument doc;
-    //        doc.open(file);
-    //        REQUIRE(doc.name() == file);
-    //    }
-    //
-    //    /**
-    //     * @brief
-    //     *
-    //     * @details
-    //     */
-    //    SECTION("Section 01D: Save document using Save()")
-    //    {
-    //        XLDocument doc(file);
-    //
-    //        doc.save();
-    //        std::ifstream n(file);
-    //        REQUIRE(n.good());
-    //        REQUIRE(doc.name() == file);
-    //    }
-    //
-    //    /**
-    //     * @brief
-    //     *
-    //     * @details
-    //     */
-    //    SECTION("Section 01E: Save document using SaveDocumentAs()")
-    //    {
-    //        XLDocument doc(file);
-    //
-    //        doc.saveAs(newfile);
-    //        std::ifstream n(newfile);
-    //        REQUIRE(n.good());
-    //        REQUIRE(doc.name() == newfile);
-    //    }
+       /**
+        * @test Create new document using the CreateDocument method.
+        *
+        * @details Creates an empty document and creates the excel file using the CreateDocument() member function.
+        * Success is tested by checking if the file have been created on disk and that the DocumentName member function
+        * returns the correct file name.
+        */
+       SECTION("Section 01A: Create new using CreateDocument()")
+       {
+           XLDocument doc;
+           doc.create(file);
+           std::ifstream f(file);
+           REQUIRE(f.good());
+           REQUIRE(doc.name() == file);
+       }
+    
+       /**
+        * @brief Open an existing document using the constructor.
+        *
+        * @details Opens an existing document by passing the file name to the constructor.
+        * Success is tested by checking that the DocumentName member function returns the correct file name.
+        */
+       SECTION("Section 01B: Open existing using Constructor")
+       {
+           XLDocument doc(file);
+           REQUIRE(doc.name() == file);
+       }
+    
+       /**
+        * @brief
+        *
+        * @details
+        */
+       SECTION("Section 01C: Open existing using openDocument()")
+       {
+           XLDocument doc;
+           doc.open(file);
+           REQUIRE(doc.name() == file);
+       }
+    
+       /**
+        * @brief
+        *
+        * @details
+        */
+       SECTION("Section 01D: Save document using Save()")
+       {
+           XLDocument doc(file);
+    
+           doc.save();
+           std::ifstream n(file);
+           REQUIRE(n.good());
+           REQUIRE(doc.name() == file);
+       }
+    
+       /**
+        * @brief
+        *
+        * @details
+        */
+       SECTION("Section 01E: Save document using SaveDocumentAs()")
+       {
+           XLDocument doc(file);
+    
+           doc.saveAs(newfile);
+           std::ifstream n(newfile);
+           REQUIRE(n.good());
+           REQUIRE(doc.name() == newfile);
+       }
     //
     //    /**
     //     * @brief
@@ -153,45 +153,45 @@ TEST_CASE("XLDocument Tests", "[XLDocument]")
     //        REQUIRE(copy.name() == file);
     //        REQUIRE_THROWS(doc.name() == file);
     //    }
-    //
-    //    /**
-    //     * @brief
-    //     *
-    //     * @details
-    //     */
-    //    SECTION("Section 01J: Close and Reopen")
-    //    {
-    //        XLDocument doc;
-    //        doc.create(file);
-    //        doc.close();
-    //        REQUIRE_THROWS(doc.name() == file);
-    //
-    //        doc.open(file);
-    //        REQUIRE(doc.name() == file);
-    //    }
-    //
-    //    /**
-    //     * @brief
-    //     *
-    //     * @details
-    //     */
-    //    SECTION("Section 01K: Reopen without closing")
-    //    {
-    //        XLDocument doc;
-    //        doc.create(file);
-    //
-    //        doc.open(newfile);
-    //        REQUIRE(doc.name() == newfile);
-    //    }
-    //
-    //    /**
-    //     * @brief
-    //     *
-    //     * @details
-    //     */
-    //    SECTION("Section 01L: Open document as const")
-    //    {
-    //        const XLDocument doc(file);
-    //        REQUIRE(doc.name() == file);
-    //    }
+    
+       /**
+        * @brief
+        *
+        * @details
+        */
+       SECTION("Section 01J: Close and Reopen")
+       {
+           XLDocument doc;
+           doc.create(file);
+           doc.close();
+           REQUIRE(doc.name() == "");
+    
+           doc.open(file);
+           REQUIRE(doc.name() == file);
+       }
+    
+       /**
+        * @brief
+        *
+        * @details
+        */
+       SECTION("Section 01K: Reopen without closing")
+       {
+           XLDocument doc;
+           doc.create(file);
+    
+           doc.open(newfile);
+           REQUIRE(doc.name() == newfile);
+       }
+    
+       /**
+        * @brief
+        *
+        * @details
+        */
+       SECTION("Section 01L: Open document as const")
+       {
+           const XLDocument doc(file);
+           REQUIRE(doc.name() == file);
+       }
 }


### PR DESCRIPTION
add new methods to class XLSheetBase for conversion of column numbers to names and vice versa (e.g. 703 <-> "AAA")

add test for these new methods

re-enable most of the test in Tests/testXLDocument.cpp

do not exclude target OpenXLSXTests from target ALL