### PR TITLE
Fixing discarding return value of function with 'nodiscard' attribute

### DIFF
--- a/OpenXLSX/sources/XLDocument.cpp
+++ b/OpenXLSX/sources/XLDocument.cpp
@@ -665,7 +665,7 @@ void XLDocument::setProperty(XLProperty prop, const std::string& value) // NOLIN
             break;
         case XLProperty::AppVersion:    // ===== TODO: Clean up this section
             try {
-                std::stof(value);
+                std::ignore = std::stof(value);
             }
             catch (...) {
                 throw XLPropertyError("Invalid property value");


### PR DESCRIPTION
Fixing error '\OpenXLSX\sources\XLDocument.cpp(668,26): warning C4834: discarding return value of function with 'nodiscard' attribute [\OpenXLSX\build\OpenXLSX.vcxproj]' when compiling with VS 2022. This fixes #173 .