### PR TITLE
Fixing problem with .pdb files in Debug version

### DIFF
--- a/OpenXLSX/CMakeLists.txt
+++ b/OpenXLSX/CMakeLists.txt
@@ -236,9 +236,13 @@ elseif (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") OR
 
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     string(REGEX REPLACE "/W[3|4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    string(REGEX REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
     target_compile_options(OpenXLSX PRIVATE $<$<CONFIG:Debug>:${OPENXLSX_DEBUG_FLAGS_MSVC}>)
     target_compile_options(OpenXLSX PRIVATE $<$<CONFIG:Release>:${OPENXLSX_RELEASE_FLAGS_MSVC}>)
 endif ()
+
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}" CACHE STRING "Flags used by the CXX compiler during DEBUG builds." FORCE)
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}" CACHE STRING "Flags used by the CXX compiler during RELEASE builds." FORCE)
 
 #=======================================================================================================================
 # Install


### PR DESCRIPTION
- replacing the default /Zi in MSVC with /Z7, so that the debugging information ends up embedded in the .lib file rather than separate .pdb files.
- forcing cmake to override the default cache