### PR TITLE
Fix loading of xlsx files without xl/workbook.xml

### DIFF
--- a/OpenXLSX/sources/XLDocument.cpp
+++ b/OpenXLSX/sources/XLDocument.cpp
@@ -461,6 +461,9 @@ void XLDocument::open(const std::string& fileName)
     if (!m_archive.hasEntry("xl/sharedStrings.xml"))
         execCommand(XLCommand(XLCommandType::AddSharedStrings));
 
+    auto items = m_contentTypes.getContentItems();
+    if(std::find_if(items.begin(), items.end(), [&](const XLContentItem& item) { return item.path() == "/xl/workbook.xml"; }) == items.end()) m_contentTypes.addOverride("/xl/workbook.xml", XLContentType::Workbook);
+   
     // ===== Add remaining spreadsheet elements to the vector of XLXmlData objects.
     for (auto& item : m_contentTypes.getContentItems()) {
         if (item.path().substr(0, 4) == "/xl/" && !(item.path() == "/xl/workbook.xml"))


### PR DESCRIPTION
I have some xlsx files that don't have a reference to `/xl/workbook.xml` in their `[Content_Types].xml`. OpenXLSX fails to open those, throwing a "path does not exist in zip archive" error. My fix checks if the `/xl/workbook.xml` reference is in `[Content_Types].xml` and adds it if it isn't.