### PR TITLE
Fix changing values of cells of type "inlineStr"

### DIFF
--- a/OpenXLSX/sources/XLCellValue.cpp
+++ b/OpenXLSX/sources/XLCellValue.cpp
@@ -197,6 +197,9 @@ XLCellValueProxy& XLCellValueProxy::clear()
 
     // ===== Remove the value node.
     m_cellNode->remove_child("v");
+    
+    // ===== Remove the is node (only relevant in case previous cell type was "inlineStr")
+    m_cellNode->remove_child("is");      
     return *this;
 }
 /**
@@ -225,6 +228,9 @@ XLCellValueProxy& XLCellValueProxy::setError(const std::string &error)
 
     // ===== Disable space preservation (only relevant for strings).
     m_cellNode->remove_attribute(" xml:space");
+    
+    // ===== Remove the is node (only relevant in case previous cell type was "inlineStr")
+    m_cellNode->remove_child("is");    
 
     return *this;
 }
@@ -318,6 +324,9 @@ void XLCellValueProxy::setInteger(int64_t numberValue)
 
     // ===== Disable space preservation (only relevant for strings).
     m_cellNode->child("v").remove_attribute(m_cellNode->child("v").attribute("xml:space"));
+    
+    // ===== Remove the is node (only relevant in case previous cell type was "inlineStr")
+    m_cellNode->remove_child("is");    
 }
 
 /**
@@ -346,6 +355,9 @@ void XLCellValueProxy::setBoolean(bool numberValue)
 
     // ===== Disable space preservation (only relevant for strings).
     m_cellNode->child("v").remove_attribute(m_cellNode->child("v").attribute("xml:space"));
+    
+    // ===== Remove the is node (only relevant in case previous cell type was "inlineStr")
+    m_cellNode->remove_child("is");    
 }
 
 /**
@@ -373,6 +385,9 @@ void XLCellValueProxy::setFloat(double numberValue)
 
         // ===== Disable space preservation (only relevant for strings).
         m_cellNode->child("v").remove_attribute(m_cellNode->child("v").attribute("xml:space"));
+        
+        // ===== Remove the is node (only relevant in case previous cell type was "inlineStr")
+        m_cellNode->remove_child("is");        
     }
     else {
         setError("#NUM!");
@@ -407,6 +422,9 @@ void XLCellValueProxy::setString(const char* stringValue)
 
     // ===== Set the text of the value node.
     m_cellNode->child("v").text().set(index);
+    
+    // ===== Remove the is node (only relevant in case previous cell type was "inlineStr")
+    m_cellNode->remove_child("is");    
 
     // IMPLEMENTATION FOR EMBEDDED STRINGS:
     //    m_cellNode->attribute("t").set_value("str");


### PR DESCRIPTION
When changing the value of a cell whose type is `inlineStr`, OpenXLSX doesn't remove the `<is>` node which contains the inlined string. This will break the XLSX document because it will now have both `<is>` and `<v>` nodes within the `<c>` node. Excel will no longer load such files. This pull request fixes the issue by removing the `<is>` node whenever a cell value is set or cleared.