### PR TITLE
Enforce formula node order and properly convert cell type to number

### DIFF
--- a/OpenXLSX/sources/XLFormula.cpp
+++ b/OpenXLSX/sources/XLFormula.cpp
@@ -163,6 +163,15 @@ void XLFormulaProxy::setFormulaString(const char* formulaString) {
     // ===== Set the text of the value node.
     m_cellNode->child("f").text().set(formulaString);
     m_cellNode->child("v").text().set(0);
+    
+    // ===== Remove "t" attribute so that the cell shows the number we've just set
+    m_cellNode->remove_attribute("t");
+    
+    // ===== Remove <is> tag in case previous type was "inlineStr"
+    m_cellNode->remove_child("is");   
+
+    // ===== Excel fails to load documents where <f> comes after <v> so make sure it is the first child    
+    m_cellNode->prepend_move(m_cellNode->child("f"));    
 }
 
 /**


### PR DESCRIPTION
For some reason my Excel version (Excel 2016) refuses to load files where `<v>` comes before `<f>`. For example, the following XML fails to load in Excel 2016:

    <v>0</v><f>A1+A2</f>

Whereas this works:

    <f>A1+A2</f><v>0</v>

I didn't find this documented anywhere but anyway, this pull request moves the `<f>` node to the front so that the formula always comes first.

It also fixes two issues in `setFormulaString`, namely that `setFormulaString` set the cell value to 0 but didn't remove the `t` attribute so that it could still be set to something like `inlineStr`. Also, `setFormulaString` didn't remove any potential `<is>` node containing an inlined string which could also break XLSX documents because it could happen that there is both, an `<is>` and a `<v>` node inside the cell value definition because `setFormulaString` will add a `<v>` node without clearing an `<is>` node which might already be there.