### PR TITLE
Support Windows and AmigaOS style paths

### DIFF
--- a/OpenXLSX/external/zippy/zippy.hpp
+++ b/OpenXLSX/external/zippy/zippy.hpp
@@ -10733,8 +10733,12 @@ namespace Zippy
                 filename = m_ArchivePath;
             }
 
+            size_t filestrt = filename.rfind('/');
+            if(filestrt == std::string::npos) filestrt = filename.rfind('\\');
+            if(filestrt == std::string::npos) filestrt = filename.rfind(':');
+
             // ===== Generate a random file name with the same path as the current file
-            std::string tempPath = filename.substr(0, filename.rfind('/') + 1) + Impl::GenerateRandomName(20);
+            std::string tempPath = filename.substr(0, filestrt + 1) + Impl::GenerateRandomName(20);
 
             // ===== Prepare an temporary archive file with the random filename;
             mz_zip_archive tempArchive = mz_zip_archive();


### PR DESCRIPTION
File part extraction won't work correctly when using backslashes instead of slashes, as it is the default on Windows. Also, filename extraction won't work on AmigaOS in case the filename comes directly after the drive letter, e.g. `T:tempfile`. This PR fixes both issues. 