### PR TITLE
Set uniqueCount correctly in sharedStrings.xml

### DIFF
--- a/OpenXLSX/sources/XLSharedStrings.cpp
+++ b/OpenXLSX/sources/XLSharedStrings.cpp
@@ -102,7 +102,7 @@ int32_t XLSharedStrings::appendString(const std::string& str)
     if (str.front() == ' ' || str.back() == ' ') textNode.append_attribute("xml:space").set_value("preserve");
 
     // TODO: this should set "count" to the total number of strings
-    size_t strCount = m_stringCache->size();
+    size_t strCount = m_stringCache->size() + 1;
     xmlDocument().document_element().attribute("uniqueCount").set_value(std::to_string(strCount).c_str());
     xmlDocument().document_element().attribute("count").set_value(std::to_string(strCount).c_str());
 

--- a/OpenXLSX/sources/XLSharedStrings.cpp
+++ b/OpenXLSX/sources/XLSharedStrings.cpp
@@ -101,6 +101,11 @@ int32_t XLSharedStrings::appendString(const std::string& str)
     auto textNode = xmlDocument().document_element().append_child("si").append_child("t");
     if (str.front() == ' ' || str.back() == ' ') textNode.append_attribute("xml:space").set_value("preserve");
 
+    // TODO: this should set "count" to the total number of strings
+    size_t strCount = m_stringCache->size();
+    xmlDocument().document_element().attribute("uniqueCount").set_value(std::to_string(strCount).c_str());
+    xmlDocument().document_element().attribute("count").set_value(std::to_string(strCount).c_str());
+
     textNode.text().set(str.c_str());
     m_stringCache->emplace_back(textNode.text().get());
 


### PR DESCRIPTION
This fixes the problem that `uniqueCount` is currently not set correctly. It will also set `count` to the same value as `uniqueCount`. This is not entirely correct because `count` should be set to the total number of strings but figuring that out is somewhat more difficult.