### PR TITLE
Fixed this-pointer check in XLCell

### DIFF
--- a/OpenXLSX/sources/XLCell.cpp
+++ b/OpenXLSX/sources/XLCell.cpp
@@ -140,7 +140,7 @@ XLCell::operator bool() const
  */
 XLCellReference XLCell::cellReference() const
 {
-    if (!*this) throw XLInternalError("XLCell object has not been properly initiated.");
+    if (!this) throw XLInternalError("XLCell object has not been properly initiated.");
     return XLCellReference{m_cellNode->attribute("r").value()};
 }
 
@@ -149,7 +149,7 @@ XLCellReference XLCell::cellReference() const
  */
 XLCell XLCell::offset(uint16_t rowOffset, uint16_t colOffset) const
 {
-    if (!*this) throw XLInternalError("XLCell object has not been properly initiated.");
+    if (!this) throw XLInternalError("XLCell object has not been properly initiated.");
     XLCellReference offsetRef(cellReference().row() + rowOffset, cellReference().column() + colOffset);
     auto            rownode  = getRowNode(m_cellNode->parent().parent(), offsetRef.row());
     auto            cellnode = getCellNode(rownode, offsetRef.column());
@@ -161,7 +161,7 @@ XLCell XLCell::offset(uint16_t rowOffset, uint16_t colOffset) const
  */
 bool XLCell::hasFormula() const
 {
-    if (!*this) return false;
+    if (!this) return false;
     return m_cellNode->child("f") != nullptr;
 }
 
@@ -170,7 +170,7 @@ bool XLCell::hasFormula() const
  */
 XLFormulaProxy& XLCell::formula()
 {
-    if (!*this) throw XLInternalError("XLCell object has not been properly initiated.");
+    if (!this) throw XLInternalError("XLCell object has not been properly initiated.");
     return m_formulaProxy;
 }
 
@@ -179,7 +179,7 @@ XLFormulaProxy& XLCell::formula()
  */
 const XLFormulaProxy& XLCell::formula() const
 {
-    if (!*this) throw XLInternalError("XLCell object has not been properly initiated.");
+    if (!this) throw XLInternalError("XLCell object has not been properly initiated.");
     return m_formulaProxy;
 }
 
@@ -189,7 +189,7 @@ const XLFormulaProxy& XLCell::formula() const
  */
 XLCellValueProxy& XLCell::value()
 {
-    if (!*this) throw XLInternalError("XLCell object has not been properly initiated.");
+    if (!this) throw XLInternalError("XLCell object has not been properly initiated.");
     return m_valueProxy;
 }
 
@@ -200,7 +200,7 @@ XLCellValueProxy& XLCell::value()
  */
 const XLCellValueProxy& XLCell::value() const
 {
-    if (!*this) throw XLInternalError("XLCell object has not been properly initiated.");
+    if (!this) throw XLInternalError("XLCell object has not been properly initiated.");
     return m_valueProxy;
 }
 


### PR DESCRIPTION
The exception is misleadingly thrown because the de-referenced this-pointer has no '!'-operator. The check should be if this-pointer itself is NULL. 