### PR TITLE
Fix temporary archive init in Zippy::ZipArchive::Save

### DIFF
--- a/OpenXLSX/external/zippy/zippy.hpp
+++ b/OpenXLSX/external/zippy/zippy.hpp
@@ -10734,11 +10734,12 @@ namespace Zippy
             }
 
             // ===== Generate a random file name with the same path as the current file
-            std::string tempPath = filename.substr(0, filename.rfind('/') + 1) + Impl::GenerateRandomName(20);
+            std::string tempPath = filename.substr(0, filename.find_last_of("/\\") + 1) + Impl::GenerateRandomName(20);
 
             // ===== Prepare an temporary archive file with the random filename;
             mz_zip_archive tempArchive = mz_zip_archive();
-            mz_zip_writer_init_file(&tempArchive, tempPath.c_str(), 0);
+            if (!mz_zip_writer_init_file(&tempArchive, tempPath.c_str(), 0))
+                throw ZipRuntimeError(mz_zip_get_error_string(tempArchive.m_last_error));
 
             // ===== Iterate through the ZipEntries and add entries to the temporary file
             for (auto& file : m_ZipEntries) {


### PR DESCRIPTION
 On branch topic/fix-ZippyTempArchive
 Changes to be committed:
	modified:   OpenXLSX/external/zippy/zippy.hpp

+ Fixed a bug in the generation of the pathname for a temporary archive used during a save operation. The implementation was peeling out the path by searching for the last '/', but Windows-based systems generally use '\'. The net result is that the temporary file is created in the current directory instead of the directory of the existing archive. If the current directory happens to be a 'protected' directory (such as the standard Program Files directories) then the file creation will fail.
+ In the scenario above, the failure to create the temporary archive was not caught, resulting in the code proceeding and eventually failing, but without any error information attached. The fix, included here, is to check the return value of mz_zip_writer_init_file and throw if it fails.