### PR TITLE
Wrapped the call to numeric_limits<int32_t>::max() function to prevent conflict with Windows.h macro expansion

### DIFF
--- a/OpenXLSX/headers/XLSharedStrings.hpp
+++ b/OpenXLSX/headers/XLSharedStrings.hpp
@@ -61,7 +61,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 
 namespace OpenXLSX
 {
-    constexpr size_t XLMaxSharedStrings = std::numeric_limits< int32_t >::max();
+    constexpr size_t XLMaxSharedStrings = (std::numeric_limits< int32_t >::max)();
 
     /**
      * @brief This class encapsulate the Excel concept of Shared Strings. In Excel, instead of havig individual strings


### PR DESCRIPTION
Fixes #260