### PR TITLE
fix si node may contain 'phoneticPr' or 'rPh'

### DIFF
--- a/OpenXLSX/sources/XLDocument.cpp
+++ b/OpenXLSX/sources/XLDocument.cpp
@@ -509,6 +509,10 @@ void XLDocument::open(const std::string& fileName)
             else {    // 2024-05-03: support a string composed of multiple <t> nodes, because LibreOffice accepts it
                 std::string result;
                 while (not elem.empty()) {
+                    if (std::string(elem.name()) == "rPh" || std::string(elem.name()) == "phoneticPr") {
+                        elem = elem.next_sibling_of_type(pugi::node_element);
+                        continue;
+                    }
                     if (elem.name() != "t"s)
                         throw XLInputError("xl/sharedStrings.xml si node \""s + node.name() + "\" is none of \"r\", \"t\", \"rPh\", \"phoneticPr\""s);
                     result += elem.text().get();


### PR DESCRIPTION
This issue happen when xlsx file edited by some xlsx editor.

For example:

<si>
    <t>英雄/士兵等级</t>
    <phoneticPr fontId="4" type="noConversion" />
</si>
<si>
    <t>兵王等级</t>
    <phoneticPr fontId="4" type="noConversion" />
</si>
[battle_robot.xlsx](https://github.com/user-attachments/files/16802099/battle_robot.xlsx)
