### PR TITLE
SEGMENTATION FAULTS TRIGGRED BY UNSUCCESSIVE FILE OPENING FIXED

### DIFF
--- a/OpenXLSX/headers/IZipArchive.hpp
+++ b/OpenXLSX/headers/IZipArchive.hpp
@@ -141,40 +141,45 @@ namespace OpenXLSX
         }
 
         inline bool isValid() const {
-            return m_zipArchive->isValid();
+            return m_zipArchive != nullptr && m_zipArchive->isValid();
 
         }
 
         inline bool isOpen() const {
-            return m_zipArchive->isOpen();
+            return m_zipArchive != nullptr && m_zipArchive->isOpen();
         }
 
         inline void open(const std::string& fileName) {
-            m_zipArchive->open(fileName);
+            if( m_zipArchive != nullptr )
+                m_zipArchive->open(fileName);
         }
 
         inline void close() const {
-            m_zipArchive->close();
+            if( m_zipArchive != nullptr )
+                m_zipArchive->close();
         }
 
         inline void save(const std::string& path) {
-            m_zipArchive->save(path);
+            if( m_zipArchive != nullptr )
+                m_zipArchive->save(path);
         }
 
         inline void addEntry(const std::string& name, const std::string& data) {
-            m_zipArchive->addEntry(name, data);
+            if( m_zipArchive != nullptr )
+                m_zipArchive->addEntry(name, data);
         }
 
         inline void deleteEntry(const std::string& entryName) {
-            m_zipArchive->deleteEntry(entryName);
+            if( m_zipArchive != nullptr )
+                m_zipArchive->deleteEntry(entryName);
         }
 
         inline std::string getEntry(const std::string& name) {
-            return m_zipArchive->getEntry(name);
+            return m_zipArchive != nullptr ? m_zipArchive->getEntry(name) : std::string();
         }
 
         inline bool hasEntry(const std::string& entryName) {
-            return m_zipArchive->hasEntry(entryName);
+            return m_zipArchive != nullptr && m_zipArchive->hasEntry(entryName);
         }
 
     private:

--- a/OpenXLSX/sources/XLZipArchive.cpp
+++ b/OpenXLSX/sources/XLZipArchive.cpp
@@ -85,7 +85,15 @@ bool XLZipArchive::isOpen() const
 void XLZipArchive::open(const std::string& fileName)
 {
     m_archive = std::make_shared<Zippy::ZipArchive>();
-    m_archive->Open(fileName);
+
+    try
+    {
+        m_archive->Open(fileName);
+    }
+    catch(...)
+    {
+        m_archive = nullptr;
+    }
 }
 
 /**
@@ -93,7 +101,8 @@ void XLZipArchive::open(const std::string& fileName)
  */
 void XLZipArchive::close()
 {
-    m_archive->Close();
+    if( m_archive != nullptr )
+        m_archive->Close();
     m_archive = nullptr;
 }
 
@@ -102,7 +111,8 @@ void XLZipArchive::close()
  */
 void XLZipArchive::save(const std::string& path) // NOLINT
 {
-    m_archive->Save(path);
+    if( m_archive != nullptr )
+        m_archive->Save(path);
 }
 
 /**
@@ -110,7 +120,8 @@ void XLZipArchive::save(const std::string& path) // NOLINT
  */
 void XLZipArchive::addEntry(const std::string& name, const std::string& data) // NOLINT
 {
-    m_archive->AddEntry(name, data);
+    if( m_archive != nullptr )
+        m_archive->AddEntry(name, data);
 }
 
 /**
@@ -118,19 +129,20 @@ void XLZipArchive::addEntry(const std::string& name, const std::string& data) //
  */
 void XLZipArchive::deleteEntry(const std::string& entryName) // NOLINT
 {
-    m_archive->DeleteEntry(entryName);
+    if( m_archive != nullptr )
+        m_archive->DeleteEntry(entryName);
 }
 
 /**
  * @details
  */
 std::string XLZipArchive::getEntry(const std::string& name) const {
-    return m_archive->GetEntry(name).GetDataAsString();
+    return m_archive != nullptr ? m_archive->GetEntry(name).GetDataAsString() : nullptr;
 }
 
 /**
  * @details
  */
 bool XLZipArchive::hasEntry(const std::string& entryName) const {
-    return m_archive->HasEntry(entryName);
+    return m_archive != nullptr && m_archive->HasEntry(entryName);
 }


### PR DESCRIPTION
[1] IZipArchive.hpp nullptr checks added to avoid segmentation fault when file could not be opened and exception has been caught

[2] XLZipArchive nullptr checks added and XLZipArchive::open(std::string) function to check an exception trhown by zippy library to avoid subsequent incorrect operation when XLZipArchive::m_archive is not valid due to file open fail