### PR TITLE
[master]: Fixing compilation due to missing #include <cstdint>

### DIFF
--- a/OpenXLSX/headers/XLCellReference.hpp
+++ b/OpenXLSX/headers/XLCellReference.hpp
@@ -53,6 +53,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 // ===== External Includes ===== //
 #include <string>
 #include <utility>
+#include <cstdint>
 
 // ===== OpenXLSX Includes ===== //
 #include "OpenXLSX-Exports.hpp"

--- a/OpenXLSX/headers/XLColor.hpp
+++ b/OpenXLSX/headers/XLColor.hpp
@@ -52,6 +52,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 
 // ===== External Includes ===== //
 #include <string>
+#include <cstdint>
 
 // ===== OpenXLSX Includes ===== //
 #include "OpenXLSX-Exports.hpp"


### PR DESCRIPTION
When using OpenXLSX with some dependency managers such as CPM, you can find a building error due to some missing header files. This small PR solves the issue