### PR TITLE
Handle pragma GCC warnings when compiling with MSVC

### DIFF
--- a/Examples/Demo5.cpp
+++ b/Examples/Demo5.cpp
@@ -1,4 +1,4 @@
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4244)
 #endif // _MSC_VER
@@ -71,6 +71,6 @@ int main()
     return 0;
 }
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #endif // _MSC_VER

--- a/Examples/Demo5.cpp
+++ b/Examples/Demo5.cpp
@@ -1,4 +1,4 @@
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
@@ -6,7 +6,7 @@
 #   pragma warning(push)
 #   pragma warning(disable : 4244)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 
@@ -78,13 +78,13 @@ int main()
     return 0;
 }
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__

--- a/Examples/Demo5.cpp
+++ b/Examples/Demo5.cpp
@@ -1,14 +1,7 @@
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4244)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #include <OpenXLSX.hpp>
 #include <iostream>
@@ -78,13 +71,6 @@ int main()
     return 0;
 }
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__

--- a/Examples/Demo5.cpp
+++ b/Examples/Demo5.cpp
@@ -1,10 +1,14 @@
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4244)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #include <OpenXLSX.hpp>
 #include <iostream>
@@ -74,9 +78,13 @@ int main()
     return 0;
 }
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__

--- a/OpenXLSX/headers/IZipArchive.hpp
+++ b/OpenXLSX/headers/IZipArchive.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_IZIPARCHIVE_HPP
 #define OPENXLSX_IZIPARCHIVE_HPP
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
@@ -55,7 +55,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 
@@ -350,14 +350,14 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 

--- a/OpenXLSX/headers/IZipArchive.hpp
+++ b/OpenXLSX/headers/IZipArchive.hpp
@@ -46,14 +46,18 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_IZIPARCHIVE_HPP
 #define OPENXLSX_IZIPARCHIVE_HPP
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 // ===== OpenXLSX Includes ===== //
 #include "OpenXLSX-Exports.hpp"
@@ -346,11 +350,15 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #endif    // OPENXLSX_IZIPARCHIVE_HPP

--- a/OpenXLSX/headers/IZipArchive.hpp
+++ b/OpenXLSX/headers/IZipArchive.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_IZIPARCHIVE_HPP
 #define OPENXLSX_IZIPARCHIVE_HPP
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
@@ -343,7 +343,7 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #endif // _MSC_VER
 

--- a/OpenXLSX/headers/IZipArchive.hpp
+++ b/OpenXLSX/headers/IZipArchive.hpp
@@ -46,18 +46,11 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_IZIPARCHIVE_HPP
 #define OPENXLSX_IZIPARCHIVE_HPP
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 // ===== OpenXLSX Includes ===== //
 #include "OpenXLSX-Exports.hpp"
@@ -350,15 +343,8 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #endif    // OPENXLSX_IZIPARCHIVE_HPP

--- a/OpenXLSX/headers/XLCell.hpp
+++ b/OpenXLSX/headers/XLCell.hpp
@@ -46,18 +46,11 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCELL_HPP
 #define OPENXLSX_XLCELL_HPP
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #include <iostream> // std::ostream
 #include <ostream>  // std::basic_ostream
@@ -366,14 +359,7 @@ namespace OpenXLSX
     }
 }    // namespace OpenXLSX
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 #endif    // OPENXLSX_XLCELL_HPP

--- a/OpenXLSX/headers/XLCell.hpp
+++ b/OpenXLSX/headers/XLCell.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCELL_HPP
 #define OPENXLSX_XLCELL_HPP
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
@@ -55,7 +55,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 
@@ -366,14 +366,14 @@ namespace OpenXLSX
     }
 }    // namespace OpenXLSX
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 #endif    // OPENXLSX_XLCELL_HPP

--- a/OpenXLSX/headers/XLCell.hpp
+++ b/OpenXLSX/headers/XLCell.hpp
@@ -46,14 +46,18 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCELL_HPP
 #define OPENXLSX_XLCELL_HPP
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #include <iostream> // std::ostream
 #include <ostream>  // std::basic_ostream
@@ -362,10 +366,14 @@ namespace OpenXLSX
     }
 }    // namespace OpenXLSX
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 #endif    // OPENXLSX_XLCELL_HPP

--- a/OpenXLSX/headers/XLCell.hpp
+++ b/OpenXLSX/headers/XLCell.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCELL_HPP
 #define OPENXLSX_XLCELL_HPP
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
@@ -359,7 +359,7 @@ namespace OpenXLSX
     }
 }    // namespace OpenXLSX
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #endif // _MSC_VER
 #endif    // OPENXLSX_XLCELL_HPP

--- a/OpenXLSX/headers/XLCellIterator.hpp
+++ b/OpenXLSX/headers/XLCellIterator.hpp
@@ -46,18 +46,11 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCELLITERATOR_HPP
 #define OPENXLSX_XLCELLITERATOR_HPP
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #include <algorithm>
 
@@ -236,15 +229,8 @@ namespace std    // NOLINT
     }
 }    // namespace std
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #endif    // OPENXLSX_XLCELLITERATOR_HPP

--- a/OpenXLSX/headers/XLCellIterator.hpp
+++ b/OpenXLSX/headers/XLCellIterator.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCELLITERATOR_HPP
 #define OPENXLSX_XLCELLITERATOR_HPP
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
@@ -55,7 +55,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 
@@ -236,14 +236,14 @@ namespace std    // NOLINT
     }
 }    // namespace std
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 

--- a/OpenXLSX/headers/XLCellIterator.hpp
+++ b/OpenXLSX/headers/XLCellIterator.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCELLITERATOR_HPP
 #define OPENXLSX_XLCELLITERATOR_HPP
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
@@ -229,7 +229,7 @@ namespace std    // NOLINT
     }
 }    // namespace std
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #endif // _MSC_VER
 

--- a/OpenXLSX/headers/XLCellIterator.hpp
+++ b/OpenXLSX/headers/XLCellIterator.hpp
@@ -46,14 +46,18 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCELLITERATOR_HPP
 #define OPENXLSX_XLCELLITERATOR_HPP
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #include <algorithm>
 
@@ -232,11 +236,15 @@ namespace std    // NOLINT
     }
 }    // namespace std
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #endif    // OPENXLSX_XLCELLITERATOR_HPP

--- a/OpenXLSX/headers/XLCellRange.hpp
+++ b/OpenXLSX/headers/XLCellRange.hpp
@@ -46,14 +46,18 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCELLRANGE_HPP
 #define OPENXLSX_XLCELLRANGE_HPP
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <memory>
@@ -225,11 +229,15 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #endif    // OPENXLSX_XLCELLRANGE_HPP

--- a/OpenXLSX/headers/XLCellRange.hpp
+++ b/OpenXLSX/headers/XLCellRange.hpp
@@ -46,18 +46,11 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCELLRANGE_HPP
 #define OPENXLSX_XLCELLRANGE_HPP
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <memory>
@@ -229,15 +222,8 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #endif    // OPENXLSX_XLCELLRANGE_HPP

--- a/OpenXLSX/headers/XLCellRange.hpp
+++ b/OpenXLSX/headers/XLCellRange.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCELLRANGE_HPP
 #define OPENXLSX_XLCELLRANGE_HPP
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
@@ -55,7 +55,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 
@@ -229,14 +229,14 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 

--- a/OpenXLSX/headers/XLCellRange.hpp
+++ b/OpenXLSX/headers/XLCellRange.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCELLRANGE_HPP
 #define OPENXLSX_XLCELLRANGE_HPP
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
@@ -222,7 +222,7 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #endif // _MSC_VER
 

--- a/OpenXLSX/headers/XLCellReference.hpp
+++ b/OpenXLSX/headers/XLCellReference.hpp
@@ -46,14 +46,18 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCELLREFERENCE_HPP
 #define OPENXLSX_XLCELLREFERENCE_HPP
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <cstdint>    // Pull request #276
@@ -313,11 +317,15 @@ namespace OpenXLSX
     inline bool operator>=(const XLCellReference& lhs, const XLCellReference& rhs) { return !(lhs < rhs); }
 }    // namespace OpenXLSX
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #endif    // OPENXLSX_XLCELLREFERENCE_HPP

--- a/OpenXLSX/headers/XLCellReference.hpp
+++ b/OpenXLSX/headers/XLCellReference.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCELLREFERENCE_HPP
 #define OPENXLSX_XLCELLREFERENCE_HPP
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
@@ -310,7 +310,7 @@ namespace OpenXLSX
     inline bool operator>=(const XLCellReference& lhs, const XLCellReference& rhs) { return !(lhs < rhs); }
 }    // namespace OpenXLSX
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #endif // _MSC_VER
 

--- a/OpenXLSX/headers/XLCellReference.hpp
+++ b/OpenXLSX/headers/XLCellReference.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCELLREFERENCE_HPP
 #define OPENXLSX_XLCELLREFERENCE_HPP
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
@@ -55,7 +55,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 
@@ -317,14 +317,14 @@ namespace OpenXLSX
     inline bool operator>=(const XLCellReference& lhs, const XLCellReference& rhs) { return !(lhs < rhs); }
 }    // namespace OpenXLSX
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 

--- a/OpenXLSX/headers/XLCellReference.hpp
+++ b/OpenXLSX/headers/XLCellReference.hpp
@@ -46,18 +46,11 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCELLREFERENCE_HPP
 #define OPENXLSX_XLCELLREFERENCE_HPP
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <cstdint>    // Pull request #276
@@ -317,15 +310,8 @@ namespace OpenXLSX
     inline bool operator>=(const XLCellReference& lhs, const XLCellReference& rhs) { return !(lhs < rhs); }
 }    // namespace OpenXLSX
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #endif    // OPENXLSX_XLCELLREFERENCE_HPP

--- a/OpenXLSX/headers/XLCellValue.hpp
+++ b/OpenXLSX/headers/XLCellValue.hpp
@@ -46,18 +46,11 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCELLVALUE_HPP
 #define OPENXLSX_XLCELLVALUE_HPP
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <cmath>
@@ -707,15 +700,8 @@ struct std::hash<OpenXLSX::XLCellValue>    // NOLINT
     }
 };
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #endif    // OPENXLSX_XLCELLVALUE_HPP

--- a/OpenXLSX/headers/XLCellValue.hpp
+++ b/OpenXLSX/headers/XLCellValue.hpp
@@ -46,14 +46,18 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCELLVALUE_HPP
 #define OPENXLSX_XLCELLVALUE_HPP
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <cmath>
@@ -703,11 +707,15 @@ struct std::hash<OpenXLSX::XLCellValue>    // NOLINT
     }
 };
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #endif    // OPENXLSX_XLCELLVALUE_HPP

--- a/OpenXLSX/headers/XLCellValue.hpp
+++ b/OpenXLSX/headers/XLCellValue.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCELLVALUE_HPP
 #define OPENXLSX_XLCELLVALUE_HPP
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
@@ -55,7 +55,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 
@@ -707,14 +707,14 @@ struct std::hash<OpenXLSX::XLCellValue>    // NOLINT
     }
 };
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 

--- a/OpenXLSX/headers/XLCellValue.hpp
+++ b/OpenXLSX/headers/XLCellValue.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCELLVALUE_HPP
 #define OPENXLSX_XLCELLVALUE_HPP
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
@@ -700,7 +700,7 @@ struct std::hash<OpenXLSX::XLCellValue>    // NOLINT
     }
 };
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #endif // _MSC_VER
 

--- a/OpenXLSX/headers/XLColor.hpp
+++ b/OpenXLSX/headers/XLColor.hpp
@@ -46,18 +46,11 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCOLOR_HPP
 #define OPENXLSX_XLCOLOR_HPP
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <cstdint>    // Pull request #276
@@ -232,15 +225,8 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #endif    // OPENXLSX_XLCOLOR_HPP

--- a/OpenXLSX/headers/XLColor.hpp
+++ b/OpenXLSX/headers/XLColor.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCOLOR_HPP
 #define OPENXLSX_XLCOLOR_HPP
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
@@ -225,7 +225,7 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #endif // _MSC_VER
 

--- a/OpenXLSX/headers/XLColor.hpp
+++ b/OpenXLSX/headers/XLColor.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCOLOR_HPP
 #define OPENXLSX_XLCOLOR_HPP
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
@@ -55,7 +55,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 
@@ -232,14 +232,14 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 

--- a/OpenXLSX/headers/XLColor.hpp
+++ b/OpenXLSX/headers/XLColor.hpp
@@ -46,14 +46,18 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCOLOR_HPP
 #define OPENXLSX_XLCOLOR_HPP
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <cstdint>    // Pull request #276
@@ -228,11 +232,15 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #endif    // OPENXLSX_XLCOLOR_HPP

--- a/OpenXLSX/headers/XLColumn.hpp
+++ b/OpenXLSX/headers/XLColumn.hpp
@@ -46,14 +46,18 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCOLUMN_HPP
 #define OPENXLSX_XLCOLUMN_HPP
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <memory>
@@ -155,11 +159,15 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #endif    // OPENXLSX_XLCOLUMN_HPP

--- a/OpenXLSX/headers/XLColumn.hpp
+++ b/OpenXLSX/headers/XLColumn.hpp
@@ -46,18 +46,11 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCOLUMN_HPP
 #define OPENXLSX_XLCOLUMN_HPP
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <memory>
@@ -159,15 +152,8 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #endif    // OPENXLSX_XLCOLUMN_HPP

--- a/OpenXLSX/headers/XLColumn.hpp
+++ b/OpenXLSX/headers/XLColumn.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCOLUMN_HPP
 #define OPENXLSX_XLCOLUMN_HPP
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
@@ -152,7 +152,7 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #endif // _MSC_VER
 

--- a/OpenXLSX/headers/XLColumn.hpp
+++ b/OpenXLSX/headers/XLColumn.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCOLUMN_HPP
 #define OPENXLSX_XLCOLUMN_HPP
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
@@ -55,7 +55,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 
@@ -159,14 +159,14 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 

--- a/OpenXLSX/headers/XLCommandQuery.hpp
+++ b/OpenXLSX/headers/XLCommandQuery.hpp
@@ -46,14 +46,18 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCOMMANDQUERY_HPP
 #define OPENXLSX_XLCOMMANDQUERY_HPP
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <any>
@@ -224,11 +228,15 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #endif    // OPENXLSX_XLCOMMANDQUERY_HPP

--- a/OpenXLSX/headers/XLCommandQuery.hpp
+++ b/OpenXLSX/headers/XLCommandQuery.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCOMMANDQUERY_HPP
 #define OPENXLSX_XLCOMMANDQUERY_HPP
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
@@ -221,7 +221,7 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #endif // _MSC_VER
 

--- a/OpenXLSX/headers/XLCommandQuery.hpp
+++ b/OpenXLSX/headers/XLCommandQuery.hpp
@@ -46,18 +46,11 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCOMMANDQUERY_HPP
 #define OPENXLSX_XLCOMMANDQUERY_HPP
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <any>
@@ -228,15 +221,8 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #endif    // OPENXLSX_XLCOMMANDQUERY_HPP

--- a/OpenXLSX/headers/XLCommandQuery.hpp
+++ b/OpenXLSX/headers/XLCommandQuery.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCOMMANDQUERY_HPP
 #define OPENXLSX_XLCOMMANDQUERY_HPP
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
@@ -55,7 +55,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 
@@ -228,14 +228,14 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 

--- a/OpenXLSX/headers/XLContentTypes.hpp
+++ b/OpenXLSX/headers/XLContentTypes.hpp
@@ -46,18 +46,11 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCONTENTTYPES_HPP
 #define OPENXLSX_XLCONTENTTYPES_HPP
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <cstdint> // uint8_t
@@ -256,15 +249,8 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #endif    // OPENXLSX_XLCONTENTTYPES_HPP

--- a/OpenXLSX/headers/XLContentTypes.hpp
+++ b/OpenXLSX/headers/XLContentTypes.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCONTENTTYPES_HPP
 #define OPENXLSX_XLCONTENTTYPES_HPP
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
@@ -249,7 +249,7 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #endif // _MSC_VER
 

--- a/OpenXLSX/headers/XLContentTypes.hpp
+++ b/OpenXLSX/headers/XLContentTypes.hpp
@@ -46,14 +46,18 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCONTENTTYPES_HPP
 #define OPENXLSX_XLCONTENTTYPES_HPP
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <cstdint> // uint8_t
@@ -252,11 +256,15 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #endif    // OPENXLSX_XLCONTENTTYPES_HPP

--- a/OpenXLSX/headers/XLContentTypes.hpp
+++ b/OpenXLSX/headers/XLContentTypes.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLCONTENTTYPES_HPP
 #define OPENXLSX_XLCONTENTTYPES_HPP
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
@@ -55,7 +55,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 
@@ -256,14 +256,14 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 

--- a/OpenXLSX/headers/XLDateTime.hpp
+++ b/OpenXLSX/headers/XLDateTime.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLDATETIME_HPP
 #define OPENXLSX_XLDATETIME_HPP
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
@@ -168,7 +168,7 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #endif // _MSC_VER
 

--- a/OpenXLSX/headers/XLDateTime.hpp
+++ b/OpenXLSX/headers/XLDateTime.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLDATETIME_HPP
 #define OPENXLSX_XLDATETIME_HPP
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
@@ -55,7 +55,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 
@@ -175,14 +175,14 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 

--- a/OpenXLSX/headers/XLDateTime.hpp
+++ b/OpenXLSX/headers/XLDateTime.hpp
@@ -46,14 +46,18 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLDATETIME_HPP
 #define OPENXLSX_XLDATETIME_HPP
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <ctime>
@@ -171,11 +175,15 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #endif    // OPENXLSX_XLDATETIME_HPP

--- a/OpenXLSX/headers/XLDateTime.hpp
+++ b/OpenXLSX/headers/XLDateTime.hpp
@@ -46,18 +46,11 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLDATETIME_HPP
 #define OPENXLSX_XLDATETIME_HPP
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <ctime>
@@ -175,15 +168,8 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #endif    // OPENXLSX_XLDATETIME_HPP

--- a/OpenXLSX/headers/XLDocument.hpp
+++ b/OpenXLSX/headers/XLDocument.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLDOCUMENT_HPP
 #define OPENXLSX_XLDOCUMENT_HPP
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
@@ -373,7 +373,7 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #endif // _MSC_VER
 

--- a/OpenXLSX/headers/XLDocument.hpp
+++ b/OpenXLSX/headers/XLDocument.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLDOCUMENT_HPP
 #define OPENXLSX_XLDOCUMENT_HPP
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
@@ -55,7 +55,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 
@@ -380,14 +380,14 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 

--- a/OpenXLSX/headers/XLDocument.hpp
+++ b/OpenXLSX/headers/XLDocument.hpp
@@ -46,14 +46,18 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLDOCUMENT_HPP
 #define OPENXLSX_XLDOCUMENT_HPP
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <algorithm> // std::find_if
@@ -376,11 +380,15 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #endif    // OPENXLSX_XLDOCUMENT_HPP

--- a/OpenXLSX/headers/XLDocument.hpp
+++ b/OpenXLSX/headers/XLDocument.hpp
@@ -46,18 +46,11 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLDOCUMENT_HPP
 #define OPENXLSX_XLDOCUMENT_HPP
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <algorithm> // std::find_if
@@ -380,15 +373,8 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #endif    // OPENXLSX_XLDOCUMENT_HPP

--- a/OpenXLSX/headers/XLException.hpp
+++ b/OpenXLSX/headers/XLException.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLEXCEPTION_HPP
 #define OPENXLSX_XLEXCEPTION_HPP
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
@@ -154,7 +154,7 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #endif // _MSC_VER
 

--- a/OpenXLSX/headers/XLException.hpp
+++ b/OpenXLSX/headers/XLException.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLEXCEPTION_HPP
 #define OPENXLSX_XLEXCEPTION_HPP
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
@@ -55,7 +55,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 
@@ -161,14 +161,14 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 

--- a/OpenXLSX/headers/XLException.hpp
+++ b/OpenXLSX/headers/XLException.hpp
@@ -46,18 +46,11 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLEXCEPTION_HPP
 #define OPENXLSX_XLEXCEPTION_HPP
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <stdexcept>    // std::runtime_error
@@ -161,15 +154,8 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #endif    // OPENXLSX_XLEXCEPTION_HPP

--- a/OpenXLSX/headers/XLException.hpp
+++ b/OpenXLSX/headers/XLException.hpp
@@ -46,14 +46,18 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLEXCEPTION_HPP
 #define OPENXLSX_XLEXCEPTION_HPP
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <stdexcept>    // std::runtime_error
@@ -157,11 +161,15 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #endif    // OPENXLSX_XLEXCEPTION_HPP

--- a/OpenXLSX/headers/XLFormula.hpp
+++ b/OpenXLSX/headers/XLFormula.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLFORMULA_HPP
 #define OPENXLSX_XLFORMULA_HPP
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
@@ -55,7 +55,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 
@@ -372,14 +372,14 @@ namespace OpenXLSX
     inline std::ostream& operator<<(std::ostream& os, const XLFormulaProxy& value) { return os << value.get(); }
 }    // namespace OpenXLSX
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 

--- a/OpenXLSX/headers/XLFormula.hpp
+++ b/OpenXLSX/headers/XLFormula.hpp
@@ -46,18 +46,11 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLFORMULA_HPP
 #define OPENXLSX_XLFORMULA_HPP
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <iostream>
@@ -372,15 +365,8 @@ namespace OpenXLSX
     inline std::ostream& operator<<(std::ostream& os, const XLFormulaProxy& value) { return os << value.get(); }
 }    // namespace OpenXLSX
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #endif    // OPENXLSX_XLFORMULA_HPP

--- a/OpenXLSX/headers/XLFormula.hpp
+++ b/OpenXLSX/headers/XLFormula.hpp
@@ -46,14 +46,18 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLFORMULA_HPP
 #define OPENXLSX_XLFORMULA_HPP
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <iostream>
@@ -368,11 +372,15 @@ namespace OpenXLSX
     inline std::ostream& operator<<(std::ostream& os, const XLFormulaProxy& value) { return os << value.get(); }
 }    // namespace OpenXLSX
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #endif    // OPENXLSX_XLFORMULA_HPP

--- a/OpenXLSX/headers/XLFormula.hpp
+++ b/OpenXLSX/headers/XLFormula.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLFORMULA_HPP
 #define OPENXLSX_XLFORMULA_HPP
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
@@ -365,7 +365,7 @@ namespace OpenXLSX
     inline std::ostream& operator<<(std::ostream& os, const XLFormulaProxy& value) { return os << value.get(); }
 }    // namespace OpenXLSX
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #endif // _MSC_VER
 

--- a/OpenXLSX/headers/XLMergeCells.hpp
+++ b/OpenXLSX/headers/XLMergeCells.hpp
@@ -46,14 +46,18 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLMERGECELLS_HPP
 #define OPENXLSX_XLMERGECELLS_HPP
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #include <deque>
 #include <limits>     // std::numeric_limits
@@ -210,11 +214,15 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #endif    // OPENXLSX_XLMERGECELLS_HPP

--- a/OpenXLSX/headers/XLMergeCells.hpp
+++ b/OpenXLSX/headers/XLMergeCells.hpp
@@ -46,18 +46,11 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLMERGECELLS_HPP
 #define OPENXLSX_XLMERGECELLS_HPP
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #include <deque>
 #include <limits>     // std::numeric_limits
@@ -214,15 +207,8 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #endif    // OPENXLSX_XLMERGECELLS_HPP

--- a/OpenXLSX/headers/XLMergeCells.hpp
+++ b/OpenXLSX/headers/XLMergeCells.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLMERGECELLS_HPP
 #define OPENXLSX_XLMERGECELLS_HPP
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
@@ -207,7 +207,7 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #endif // _MSC_VER
 

--- a/OpenXLSX/headers/XLMergeCells.hpp
+++ b/OpenXLSX/headers/XLMergeCells.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLMERGECELLS_HPP
 #define OPENXLSX_XLMERGECELLS_HPP
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
@@ -55,7 +55,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 
@@ -214,14 +214,14 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 

--- a/OpenXLSX/headers/XLProperties.hpp
+++ b/OpenXLSX/headers/XLProperties.hpp
@@ -46,18 +46,11 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLPROPERTIES_HPP
 #define OPENXLSX_XLPROPERTIES_HPP
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <string>
@@ -336,15 +329,8 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #endif    // OPENXLSX_XLPROPERTIES_HPP

--- a/OpenXLSX/headers/XLProperties.hpp
+++ b/OpenXLSX/headers/XLProperties.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLPROPERTIES_HPP
 #define OPENXLSX_XLPROPERTIES_HPP
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
@@ -329,7 +329,7 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #endif // _MSC_VER
 

--- a/OpenXLSX/headers/XLProperties.hpp
+++ b/OpenXLSX/headers/XLProperties.hpp
@@ -46,14 +46,18 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLPROPERTIES_HPP
 #define OPENXLSX_XLPROPERTIES_HPP
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <string>
@@ -332,11 +336,15 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #endif    // OPENXLSX_XLPROPERTIES_HPP

--- a/OpenXLSX/headers/XLProperties.hpp
+++ b/OpenXLSX/headers/XLProperties.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLPROPERTIES_HPP
 #define OPENXLSX_XLPROPERTIES_HPP
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
@@ -55,7 +55,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 
@@ -336,14 +336,14 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 

--- a/OpenXLSX/headers/XLRelationships.hpp
+++ b/OpenXLSX/headers/XLRelationships.hpp
@@ -46,14 +46,18 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLRELATIONSHIPS_HPP
 #define OPENXLSX_XLRELATIONSHIPS_HPP
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <random>       // std::mt19937
@@ -338,11 +342,15 @@ namespace OpenXLSX {
     };
 }    // namespace OpenXLSX
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #endif    // OPENXLSX_XLRELATIONSHIPS_HPP

--- a/OpenXLSX/headers/XLRelationships.hpp
+++ b/OpenXLSX/headers/XLRelationships.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLRELATIONSHIPS_HPP
 #define OPENXLSX_XLRELATIONSHIPS_HPP
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
@@ -335,7 +335,7 @@ namespace OpenXLSX {
     };
 }    // namespace OpenXLSX
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #endif // _MSC_VER
 

--- a/OpenXLSX/headers/XLRelationships.hpp
+++ b/OpenXLSX/headers/XLRelationships.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLRELATIONSHIPS_HPP
 #define OPENXLSX_XLRELATIONSHIPS_HPP
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
@@ -55,7 +55,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 
@@ -342,14 +342,14 @@ namespace OpenXLSX {
     };
 }    // namespace OpenXLSX
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 

--- a/OpenXLSX/headers/XLRelationships.hpp
+++ b/OpenXLSX/headers/XLRelationships.hpp
@@ -46,18 +46,11 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLRELATIONSHIPS_HPP
 #define OPENXLSX_XLRELATIONSHIPS_HPP
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <random>       // std::mt19937
@@ -342,15 +335,8 @@ namespace OpenXLSX {
     };
 }    // namespace OpenXLSX
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #endif    // OPENXLSX_XLRELATIONSHIPS_HPP

--- a/OpenXLSX/headers/XLRow.hpp
+++ b/OpenXLSX/headers/XLRow.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLROW_HPP
 #define OPENXLSX_XLROW_HPP
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
@@ -55,7 +55,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 
@@ -503,14 +503,14 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 

--- a/OpenXLSX/headers/XLRow.hpp
+++ b/OpenXLSX/headers/XLRow.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLROW_HPP
 #define OPENXLSX_XLROW_HPP
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
@@ -496,7 +496,7 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #endif // _MSC_VER
 

--- a/OpenXLSX/headers/XLRow.hpp
+++ b/OpenXLSX/headers/XLRow.hpp
@@ -46,18 +46,11 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLROW_HPP
 #define OPENXLSX_XLROW_HPP
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 // ===== OpenXLSX Includes ===== //
 #include "OpenXLSX-Exports.hpp"
@@ -503,15 +496,8 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #endif    // OPENXLSX_XLROW_HPP

--- a/OpenXLSX/headers/XLRow.hpp
+++ b/OpenXLSX/headers/XLRow.hpp
@@ -46,14 +46,18 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLROW_HPP
 #define OPENXLSX_XLROW_HPP
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 // ===== OpenXLSX Includes ===== //
 #include "OpenXLSX-Exports.hpp"
@@ -499,11 +503,15 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #endif    // OPENXLSX_XLROW_HPP

--- a/OpenXLSX/headers/XLRowData.hpp
+++ b/OpenXLSX/headers/XLRowData.hpp
@@ -5,18 +5,11 @@
 #ifndef OPENXLSX_XLROWDATA_HPP
 #define OPENXLSX_XLROWDATA_HPP
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <deque>
@@ -476,15 +469,8 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #endif    // OPENXLSX_XLROWDATA_HPP

--- a/OpenXLSX/headers/XLRowData.hpp
+++ b/OpenXLSX/headers/XLRowData.hpp
@@ -5,14 +5,18 @@
 #ifndef OPENXLSX_XLROWDATA_HPP
 #define OPENXLSX_XLROWDATA_HPP
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <deque>
@@ -472,11 +476,15 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #endif    // OPENXLSX_XLROWDATA_HPP

--- a/OpenXLSX/headers/XLRowData.hpp
+++ b/OpenXLSX/headers/XLRowData.hpp
@@ -5,7 +5,7 @@
 #ifndef OPENXLSX_XLROWDATA_HPP
 #define OPENXLSX_XLROWDATA_HPP
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
@@ -469,7 +469,7 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #endif // _MSC_VER
 

--- a/OpenXLSX/headers/XLRowData.hpp
+++ b/OpenXLSX/headers/XLRowData.hpp
@@ -5,7 +5,7 @@
 #ifndef OPENXLSX_XLROWDATA_HPP
 #define OPENXLSX_XLROWDATA_HPP
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
@@ -14,7 +14,7 @@
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 
@@ -476,14 +476,14 @@ namespace OpenXLSX
 
 }    // namespace OpenXLSX
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 

--- a/OpenXLSX/headers/XLSharedStrings.hpp
+++ b/OpenXLSX/headers/XLSharedStrings.hpp
@@ -46,18 +46,11 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLSHAREDSTRINGS_HPP
 #define OPENXLSX_XLSHAREDSTRINGS_HPP
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #include <deque>
 #include <limits>     // std::numeric_limits
@@ -182,15 +175,8 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #endif    // OPENXLSX_XLSHAREDSTRINGS_HPP

--- a/OpenXLSX/headers/XLSharedStrings.hpp
+++ b/OpenXLSX/headers/XLSharedStrings.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLSHAREDSTRINGS_HPP
 #define OPENXLSX_XLSHAREDSTRINGS_HPP
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
@@ -55,7 +55,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 
@@ -182,14 +182,14 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 

--- a/OpenXLSX/headers/XLSharedStrings.hpp
+++ b/OpenXLSX/headers/XLSharedStrings.hpp
@@ -46,14 +46,18 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLSHAREDSTRINGS_HPP
 #define OPENXLSX_XLSHAREDSTRINGS_HPP
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #include <deque>
 #include <limits>     // std::numeric_limits
@@ -178,11 +182,15 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #endif    // OPENXLSX_XLSHAREDSTRINGS_HPP

--- a/OpenXLSX/headers/XLSharedStrings.hpp
+++ b/OpenXLSX/headers/XLSharedStrings.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLSHAREDSTRINGS_HPP
 #define OPENXLSX_XLSHAREDSTRINGS_HPP
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
@@ -175,7 +175,7 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #endif // _MSC_VER
 

--- a/OpenXLSX/headers/XLSheet.hpp
+++ b/OpenXLSX/headers/XLSheet.hpp
@@ -46,14 +46,18 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLSHEET_HPP
 #define OPENXLSX_XLSHEET_HPP
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <cstdint>    // uint8_t, uint16_t, uint32_t
@@ -842,11 +846,15 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #endif    // OPENXLSX_XLSHEET_HPP

--- a/OpenXLSX/headers/XLSheet.hpp
+++ b/OpenXLSX/headers/XLSheet.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLSHEET_HPP
 #define OPENXLSX_XLSHEET_HPP
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
@@ -839,7 +839,7 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #endif // _MSC_VER
 

--- a/OpenXLSX/headers/XLSheet.hpp
+++ b/OpenXLSX/headers/XLSheet.hpp
@@ -46,18 +46,11 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLSHEET_HPP
 #define OPENXLSX_XLSHEET_HPP
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <cstdint>    // uint8_t, uint16_t, uint32_t
@@ -846,15 +839,8 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #endif    // OPENXLSX_XLSHEET_HPP

--- a/OpenXLSX/headers/XLSheet.hpp
+++ b/OpenXLSX/headers/XLSheet.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLSHEET_HPP
 #define OPENXLSX_XLSHEET_HPP
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
@@ -55,7 +55,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 
@@ -846,14 +846,14 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 

--- a/OpenXLSX/headers/XLStyles.hpp
+++ b/OpenXLSX/headers/XLStyles.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLSTYLES_HPP
 #define OPENXLSX_XLSTYLES_HPP
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
@@ -55,7 +55,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 
@@ -2207,14 +2207,14 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 

--- a/OpenXLSX/headers/XLStyles.hpp
+++ b/OpenXLSX/headers/XLStyles.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLSTYLES_HPP
 #define OPENXLSX_XLSTYLES_HPP
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
@@ -2200,7 +2200,7 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #endif // _MSC_VER
 

--- a/OpenXLSX/headers/XLStyles.hpp
+++ b/OpenXLSX/headers/XLStyles.hpp
@@ -46,14 +46,18 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLSTYLES_HPP
 #define OPENXLSX_XLSTYLES_HPP
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <cstdint>   // uint32_t etc
@@ -2203,11 +2207,15 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #endif    // OPENXLSX_XLSTYLES_HPP

--- a/OpenXLSX/headers/XLStyles.hpp
+++ b/OpenXLSX/headers/XLStyles.hpp
@@ -46,18 +46,11 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLSTYLES_HPP
 #define OPENXLSX_XLSTYLES_HPP
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <cstdint>   // uint32_t etc
@@ -2207,15 +2200,8 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #endif    // OPENXLSX_XLSTYLES_HPP

--- a/OpenXLSX/headers/XLWorkbook.hpp
+++ b/OpenXLSX/headers/XLWorkbook.hpp
@@ -46,14 +46,18 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLWORKBOOK_HPP
 #define OPENXLSX_XLWORKBOOK_HPP
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <ostream>    // std::basic_ostream
@@ -400,11 +404,15 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #endif    // OPENXLSX_XLWORKBOOK_HPP

--- a/OpenXLSX/headers/XLWorkbook.hpp
+++ b/OpenXLSX/headers/XLWorkbook.hpp
@@ -46,18 +46,11 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLWORKBOOK_HPP
 #define OPENXLSX_XLWORKBOOK_HPP
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <ostream>    // std::basic_ostream
@@ -404,15 +397,8 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #endif    // OPENXLSX_XLWORKBOOK_HPP

--- a/OpenXLSX/headers/XLWorkbook.hpp
+++ b/OpenXLSX/headers/XLWorkbook.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLWORKBOOK_HPP
 #define OPENXLSX_XLWORKBOOK_HPP
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
@@ -55,7 +55,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 
@@ -404,14 +404,14 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 

--- a/OpenXLSX/headers/XLWorkbook.hpp
+++ b/OpenXLSX/headers/XLWorkbook.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLWORKBOOK_HPP
 #define OPENXLSX_XLWORKBOOK_HPP
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
@@ -397,7 +397,7 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #endif // _MSC_VER
 

--- a/OpenXLSX/headers/XLXmlData.hpp
+++ b/OpenXLSX/headers/XLXmlData.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLXMLDATA_HPP
 #define OPENXLSX_XLXMLDATA_HPP
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
@@ -55,7 +55,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 
@@ -237,14 +237,14 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 

--- a/OpenXLSX/headers/XLXmlData.hpp
+++ b/OpenXLSX/headers/XLXmlData.hpp
@@ -46,14 +46,18 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLXMLDATA_HPP
 #define OPENXLSX_XLXMLDATA_HPP
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <memory>
@@ -233,11 +237,15 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #endif    // OPENXLSX_XLXMLDATA_HPP

--- a/OpenXLSX/headers/XLXmlData.hpp
+++ b/OpenXLSX/headers/XLXmlData.hpp
@@ -46,18 +46,11 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLXMLDATA_HPP
 #define OPENXLSX_XLXMLDATA_HPP
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 // ===== External Includes ===== //
 #include <memory>
@@ -237,15 +230,8 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #endif    // OPENXLSX_XLXMLDATA_HPP

--- a/OpenXLSX/headers/XLXmlData.hpp
+++ b/OpenXLSX/headers/XLXmlData.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLXMLDATA_HPP
 #define OPENXLSX_XLXMLDATA_HPP
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
@@ -230,7 +230,7 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #endif // _MSC_VER
 

--- a/OpenXLSX/headers/XLXmlFile.hpp
+++ b/OpenXLSX/headers/XLXmlFile.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLXMLFILE_HPP
 #define OPENXLSX_XLXMLFILE_HPP
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
@@ -55,7 +55,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 
@@ -168,14 +168,14 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 

--- a/OpenXLSX/headers/XLXmlFile.hpp
+++ b/OpenXLSX/headers/XLXmlFile.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLXMLFILE_HPP
 #define OPENXLSX_XLXMLFILE_HPP
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
@@ -161,7 +161,7 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #endif // _MSC_VER
 

--- a/OpenXLSX/headers/XLXmlFile.hpp
+++ b/OpenXLSX/headers/XLXmlFile.hpp
@@ -46,14 +46,18 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLXMLFILE_HPP
 #define OPENXLSX_XLXMLFILE_HPP
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 // ===== OpenXLSX Includes ===== //
 #include "OpenXLSX-Exports.hpp"
@@ -164,11 +168,15 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #endif    // OPENXLSX_XLXMLFILE_HPP

--- a/OpenXLSX/headers/XLXmlFile.hpp
+++ b/OpenXLSX/headers/XLXmlFile.hpp
@@ -46,18 +46,11 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLXMLFILE_HPP
 #define OPENXLSX_XLXMLFILE_HPP
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 // ===== OpenXLSX Includes ===== //
 #include "OpenXLSX-Exports.hpp"
@@ -168,15 +161,8 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #endif    // OPENXLSX_XLXMLFILE_HPP

--- a/OpenXLSX/headers/XLZipArchive.hpp
+++ b/OpenXLSX/headers/XLZipArchive.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLZIPARCHIVE_HPP
 #define OPENXLSX_XLZIPARCHIVE_HPP
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
@@ -167,7 +167,7 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #endif // _MSC_VER
 

--- a/OpenXLSX/headers/XLZipArchive.hpp
+++ b/OpenXLSX/headers/XLZipArchive.hpp
@@ -46,14 +46,18 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLZIPARCHIVE_HPP
 #define OPENXLSX_XLZIPARCHIVE_HPP
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 // ===== OpenXLSX Includes ===== //
 #include "OpenXLSX-Exports.hpp"
@@ -170,11 +174,15 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
+#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #endif    // OPENXLSX_XLZIPARCHIVE_HPP

--- a/OpenXLSX/headers/XLZipArchive.hpp
+++ b/OpenXLSX/headers/XLZipArchive.hpp
@@ -46,18 +46,11 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLZIPARCHIVE_HPP
 #define OPENXLSX_XLZIPARCHIVE_HPP
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(push)
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 // ===== OpenXLSX Includes ===== //
 #include "OpenXLSX-Exports.hpp"
@@ -174,15 +167,8 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
-#endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 
 #endif    // OPENXLSX_XLZIPARCHIVE_HPP

--- a/OpenXLSX/headers/XLZipArchive.hpp
+++ b/OpenXLSX/headers/XLZipArchive.hpp
@@ -46,7 +46,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #ifndef OPENXLSX_XLZIPARCHIVE_HPP
 #define OPENXLSX_XLZIPARCHIVE_HPP
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
@@ -55,7 +55,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #   pragma warning(disable : 4251)
 #   pragma warning(disable : 4275)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 
@@ -174,14 +174,14 @@ namespace OpenXLSX
     };
 }    // namespace OpenXLSX
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas" // disable warning about below #pragma warning being unknown
 #endif // __GNUC__
 #ifdef _MSC_VER                                    // additional condition because the previous line does not work on gcc 12.2
 #   pragma warning(pop)
 #endif // _MSC_VER
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 

--- a/OpenXLSX/sources/XLDocument.cpp
+++ b/OpenXLSX/sources/XLDocument.cpp
@@ -624,8 +624,10 @@ namespace {
             return true;
         return false;
     }
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
+#endif // __GNUC__
     /**
      * @brief Test if fileName exists and is not a directory
      * @param fileName The path to check for existence (as a file)
@@ -647,7 +649,9 @@ namespace {
                 return true;
         return false;
     }
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 } // anonymous namespace
 
 /**

--- a/OpenXLSX/sources/XLDocument.cpp
+++ b/OpenXLSX/sources/XLDocument.cpp
@@ -624,7 +624,7 @@ namespace {
             return true;
         return false;
     }
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
 #endif // __GNUC__
@@ -649,7 +649,7 @@ namespace {
                 return true;
         return false;
     }
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 } // anonymous namespace

--- a/OpenXLSX/sources/XLProperties.cpp
+++ b/OpenXLSX/sources/XLProperties.cpp
@@ -121,7 +121,7 @@ namespace    // anonymous namespace for module local functions
         return docNode.child("HeadingPairs").first_child_of_type(pugi::node_element).attribute("size");
     }
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
 #endif // __GNUC__
@@ -138,7 +138,7 @@ namespace    // anonymous namespace for module local functions
         return result; // 2024-05-28: std::move should not be used when the operand of a return statement is the name of a local variable
                        // as this can prevent named return value optimization (NRVO, copy elision)
     }
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 

--- a/OpenXLSX/sources/XLProperties.cpp
+++ b/OpenXLSX/sources/XLProperties.cpp
@@ -121,8 +121,10 @@ namespace    // anonymous namespace for module local functions
         return docNode.child("HeadingPairs").first_child_of_type(pugi::node_element).attribute("size");
     }
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
+#endif // __GNUC__
     std::vector<std::string> headingPairsCategoriesStrings(XMLNode docNode)
     {
         // 2024-05-28 DONE: tested this code with two pairs in headingPairsNode
@@ -136,7 +138,9 @@ namespace    // anonymous namespace for module local functions
         return result; // 2024-05-28: std::move should not be used when the operand of a return statement is the name of a local variable
                        // as this can prevent named return value optimization (NRVO, copy elision)
     }
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
     /**
      * @brief fetch the <TitlesOfParts><vt:vector> XML node, create if not existing

--- a/OpenXLSX/sources/XLStyles.cpp
+++ b/OpenXLSX/sources/XLStyles.cpp
@@ -286,7 +286,7 @@ namespace     // anonymous namespace for module local functions
     }
 #if __GNUC__>=5
 #pragma GCC diagnostic pop
-#endif
+#endif // __GNUC__
 
     std::string XLLineTypeToString(XLLineType lineType)
     {

--- a/OpenXLSX/sources/XLStyles.cpp
+++ b/OpenXLSX/sources/XLStyles.cpp
@@ -268,8 +268,10 @@ namespace     // anonymous namespace for module local functions
         }
     }
 
+#if __GNUC__>=5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
+#endif // __GNUC__
     XLLineType XLLineTypeFromString(std::string lineType)
     {
         if (lineType == "left")       return XLLineLeft;
@@ -282,7 +284,9 @@ namespace     // anonymous namespace for module local functions
         std::cerr << __func__ << ": invalid line type" << lineType << std::endl;
         return XLLineInvalid;
     }
+#if __GNUC__>=5
 #pragma GCC diagnostic pop
+#endif
 
     std::string XLLineTypeToString(XLLineType lineType)
     {

--- a/OpenXLSX/sources/XLStyles.cpp
+++ b/OpenXLSX/sources/XLStyles.cpp
@@ -268,7 +268,7 @@ namespace     // anonymous namespace for module local functions
         }
     }
 
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
 #endif // __GNUC__
@@ -284,7 +284,7 @@ namespace     // anonymous namespace for module local functions
         std::cerr << __func__ << ": invalid line type" << lineType << std::endl;
         return XLLineInvalid;
     }
-#if __GNUC__>=5
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif // __GNUC__
 


### PR DESCRIPTION
When compiling with MSVC lots of pragma GCC warning pops up. This PR aims to fix that.