### PR TITLE
Add building support for SwiftPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,9 @@
 !/OpenXLSX/external/*
 !/OpenXLSX/headers
 !/OpenXLSX/headers/*
+!/OpenXLSX/module.modulemap
+!/OpenXLSX/swiftpm
+!/OpenXLSX/swiftpm/*
 !/OpenXLSX/OpenXLSXConfig.cmake
 !/OpenXLSX/OpenXLSX.hpp
 !/OpenXLSX/sources
@@ -103,3 +106,5 @@
 !/Tests/catch/*.hpp
 !/Tests/CMakeLists.txt
 !/Tests/*.cpp
+
+!/Package.swift

--- a/OpenXLSX/CMakeLists.txt
+++ b/OpenXLSX/CMakeLists.txt
@@ -185,6 +185,7 @@ if ("${OPENXLSX_LIBRARY_TYPE}" STREQUAL "SHARED")
 
 endif()
 
+target_compile_definitions(OpenXLSX PUBLIC OPENXLSX_CMAKE)
 
 if (OPENXLSX_ENABLE_NOWIDE)
     target_compile_definitions(OpenXLSX PRIVATE ENABLE_NOWIDE)

--- a/OpenXLSX/headers/IZipArchive.hpp
+++ b/OpenXLSX/headers/IZipArchive.hpp
@@ -53,7 +53,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #endif // _MSC_VER
 
 // ===== OpenXLSX Includes ===== //
-#include "OpenXLSX-Exports.hpp"
+#include "include-exports-header.hpp"
 
 #include <memory>
 #include <string>

--- a/OpenXLSX/headers/XLCell.hpp
+++ b/OpenXLSX/headers/XLCell.hpp
@@ -57,7 +57,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #include <memory>
 
 // ===== OpenXLSX Includes ===== //
-#include "OpenXLSX-Exports.hpp"
+#include "include-exports-header.hpp"
 #include "XLCellReference.hpp"
 #include "XLCellValue.hpp"
 #include "XLFormula.hpp"
@@ -259,7 +259,7 @@ namespace OpenXLSX
          * @brief Copy constructor. Constructs an assignable XLCell from an existing cell
          * @param other the cell to construct from
          */
-        XLCellAssignable (XLCell const & other);
+        XLCellAssignable (XLCellAssignable const & other);
 
         /**
          * @brief Move constructor. Constructs an assignable XLCell from a temporary (r)value

--- a/OpenXLSX/headers/XLCell.hpp
+++ b/OpenXLSX/headers/XLCell.hpp
@@ -259,7 +259,7 @@ namespace OpenXLSX
          * @brief Copy constructor. Constructs an assignable XLCell from an existing cell
          * @param other the cell to construct from
          */
-        XLCellAssignable (XLCellAssignable const & other);
+        XLCellAssignable (XLCell const & other);
 
         /**
          * @brief Move constructor. Constructs an assignable XLCell from a temporary (r)value

--- a/OpenXLSX/headers/XLCellIterator.hpp
+++ b/OpenXLSX/headers/XLCellIterator.hpp
@@ -54,7 +54,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 
 #include <algorithm>
 
-#include "OpenXLSX-Exports.hpp"
+#include "include-exports-header.hpp"
 #include "XLCell.hpp"
 #include "XLCellReference.hpp"
 #include "XLIterator.hpp"

--- a/OpenXLSX/headers/XLCellRange.hpp
+++ b/OpenXLSX/headers/XLCellRange.hpp
@@ -56,7 +56,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #include <memory>
 
 // ===== OpenXLSX Includes ===== //
-#include "OpenXLSX-Exports.hpp"
+#include "include-exports-header.hpp"
 #include "XLCell.hpp"
 #include "XLCellIterator.hpp"
 #include "XLCellReference.hpp"

--- a/OpenXLSX/headers/XLCellReference.hpp
+++ b/OpenXLSX/headers/XLCellReference.hpp
@@ -58,7 +58,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #include <utility>
 
 // ===== OpenXLSX Includes ===== //
-#include "OpenXLSX-Exports.hpp"
+#include "include-exports-header.hpp"
 
 namespace OpenXLSX
 {

--- a/OpenXLSX/headers/XLCellValue.hpp
+++ b/OpenXLSX/headers/XLCellValue.hpp
@@ -60,7 +60,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #include <variant>
 
 // ===== OpenXLSX Includes ===== //
-#include "OpenXLSX-Exports.hpp"
+#include "include-exports-header.hpp"
 #include "XLDateTime.hpp"
 #include "XLException.hpp"
 #include "XLXmlParser.hpp"

--- a/OpenXLSX/headers/XLColor.hpp
+++ b/OpenXLSX/headers/XLColor.hpp
@@ -57,7 +57,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #include <string>
 
 // ===== OpenXLSX Includes ===== //
-#include "OpenXLSX-Exports.hpp"
+#include "include-exports-header.hpp"
 
 namespace OpenXLSX
 {

--- a/OpenXLSX/headers/XLColumn.hpp
+++ b/OpenXLSX/headers/XLColumn.hpp
@@ -56,7 +56,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #include <memory>
 
 // ===== OpenXLSX Includes ===== //
-#include "OpenXLSX-Exports.hpp"
+#include "include-exports-header.hpp"
 #include "XLStyles.hpp"          // XLStyleIndex
 #include "XLXmlParser.hpp"
 

--- a/OpenXLSX/headers/XLComments.hpp
+++ b/OpenXLSX/headers/XLComments.hpp
@@ -53,7 +53,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 // #include <variant>
 
 // ===== OpenXLSX Includes ===== //
-#include "OpenXLSX-Exports.hpp"
+#include "include-exports-header.hpp"
 // #include "XLCell.hpp"
 // #include "XLCellReference.hpp"
 // #include "XLColor.hpp"

--- a/OpenXLSX/headers/XLContentTypes.hpp
+++ b/OpenXLSX/headers/XLContentTypes.hpp
@@ -59,7 +59,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #include <vector>
 
 // ===== OpenXLSX Includes ===== //
-#include "OpenXLSX-Exports.hpp"
+#include "include-exports-header.hpp"
 #include "XLXmlFile.hpp"
 #include "XLXmlParser.hpp"
 

--- a/OpenXLSX/headers/XLDateTime.hpp
+++ b/OpenXLSX/headers/XLDateTime.hpp
@@ -56,7 +56,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #include <ctime>
 
 // ===== OpenXLSX Includes ===== //
-#include "OpenXLSX-Exports.hpp"
+#include "include-exports-header.hpp"
 #include "XLException.hpp"
 
 // ========== CLASS AND ENUM TYPE DEFINITIONS ========== //

--- a/OpenXLSX/headers/XLDocument.hpp
+++ b/OpenXLSX/headers/XLDocument.hpp
@@ -59,7 +59,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 
 // ===== OpenXLSX Includes ===== //
 #include "IZipArchive.hpp"
-#include "OpenXLSX-Exports.hpp"
+#include "include-exports-header.hpp"
 #include "XLCommandQuery.hpp"
 #include "XLContentTypes.hpp"
 #include "XLProperties.hpp"

--- a/OpenXLSX/headers/XLException.hpp
+++ b/OpenXLSX/headers/XLException.hpp
@@ -57,7 +57,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #include <string>       // std::string - Issue #278 should be resolved by this
 
 // ===== OpenXLSX Includes ===== //
-#include "OpenXLSX-Exports.hpp"
+#include "include-exports-header.hpp"
 
 namespace OpenXLSX
 {

--- a/OpenXLSX/headers/XLFormula.hpp
+++ b/OpenXLSX/headers/XLFormula.hpp
@@ -58,7 +58,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #include <variant>
 
 // ===== OpenXLSX Includes ===== //
-#include "OpenXLSX-Exports.hpp"
+#include "include-exports-header.hpp"
 #include "XLXmlParser.hpp"
 
 // ========== CLASS AND ENUM TYPE DEFINITIONS ========== //

--- a/OpenXLSX/headers/XLMergeCells.hpp
+++ b/OpenXLSX/headers/XLMergeCells.hpp
@@ -59,7 +59,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #include <string>
 
 // ===== OpenXLSX Includes ===== //
-#include "OpenXLSX-Exports.hpp"
+#include "include-exports-header.hpp"
 #include "XLCellReference.hpp"
 #include "XLXmlParser.hpp" // XMLNode, pugi node types
 

--- a/OpenXLSX/headers/XLProperties.hpp
+++ b/OpenXLSX/headers/XLProperties.hpp
@@ -56,7 +56,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #include <string>
 
 // ===== OpenXLSX Includes ===== //
-#include "OpenXLSX-Exports.hpp"
+#include "include-exports-header.hpp"
 #include "XLXmlFile.hpp"
 
 namespace OpenXLSX

--- a/OpenXLSX/headers/XLRelationships.hpp
+++ b/OpenXLSX/headers/XLRelationships.hpp
@@ -58,7 +58,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #include <vector>
 
 // ===== OpenXLSX Includes ===== //
-#include "OpenXLSX-Exports.hpp"
+#include "include-exports-header.hpp"
 #include "XLXmlFile.hpp"
 #include "XLXmlParser.hpp"
 

--- a/OpenXLSX/headers/XLRow.hpp
+++ b/OpenXLSX/headers/XLRow.hpp
@@ -53,7 +53,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #endif // _MSC_VER
 
 // ===== OpenXLSX Includes ===== //
-#include "OpenXLSX-Exports.hpp"
+#include "include-exports-header.hpp"
 #include "XLRowData.hpp"
 
 // ========== CLASS AND ENUM TYPE DEFINITIONS ========== //

--- a/OpenXLSX/headers/XLRowData.hpp
+++ b/OpenXLSX/headers/XLRowData.hpp
@@ -19,7 +19,7 @@
 #include <vector>
 
 // ===== OpenXLSX Includes ===== //
-#include "OpenXLSX-Exports.hpp"
+#include "include-exports-header.hpp"
 #include "XLCell.hpp"
 #include "XLConstants.hpp"
 #include "XLException.hpp"

--- a/OpenXLSX/headers/XLSharedStrings.hpp
+++ b/OpenXLSX/headers/XLSharedStrings.hpp
@@ -58,7 +58,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #include <string>
 
 // ===== OpenXLSX Includes ===== //
-#include "OpenXLSX-Exports.hpp"
+#include "include-exports-header.hpp"
 #include "XLXmlFile.hpp"
 
 namespace OpenXLSX

--- a/OpenXLSX/headers/XLSheet.hpp
+++ b/OpenXLSX/headers/XLSheet.hpp
@@ -59,7 +59,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #include <variant>
 
 // ===== OpenXLSX Includes ===== //
-#include "OpenXLSX-Exports.hpp"
+#include "include-exports-header.hpp"
 #include "XLCell.hpp"
 #include "XLCellReference.hpp"
 #include "XLColor.hpp"

--- a/OpenXLSX/headers/XLStyles.hpp
+++ b/OpenXLSX/headers/XLStyles.hpp
@@ -58,7 +58,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #include <vector>
 
 // ===== OpenXLSX Includes ===== //
-#include "OpenXLSX-Exports.hpp"
+#include "include-exports-header.hpp"
 #include "XLColor.hpp"
 #include "XLXmlFile.hpp"
 #include "XLXmlParser.hpp"

--- a/OpenXLSX/headers/XLWorkbook.hpp
+++ b/OpenXLSX/headers/XLWorkbook.hpp
@@ -57,7 +57,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #include <vector>
 
 // ===== OpenXLSX Includes ===== //
-#include "OpenXLSX-Exports.hpp"
+#include "include-exports-header.hpp"
 #include "XLXmlFile.hpp"
 
 namespace OpenXLSX

--- a/OpenXLSX/headers/XLXmlData.hpp
+++ b/OpenXLSX/headers/XLXmlData.hpp
@@ -57,7 +57,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #include <string>
 
 // ===== OpenXLSX Includes ===== //
-#include "OpenXLSX-Exports.hpp"
+#include "include-exports-header.hpp"
 #include "XLContentTypes.hpp"
 #include "XLXmlParser.hpp"
 

--- a/OpenXLSX/headers/XLXmlFile.hpp
+++ b/OpenXLSX/headers/XLXmlFile.hpp
@@ -53,7 +53,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #endif // _MSC_VER
 
 // ===== OpenXLSX Includes ===== //
-#include "OpenXLSX-Exports.hpp"
+#include "include-exports-header.hpp"
 #include "XLXmlParser.hpp"
 
 namespace OpenXLSX

--- a/OpenXLSX/headers/XLXmlParser.hpp
+++ b/OpenXLSX/headers/XLXmlParser.hpp
@@ -50,7 +50,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 
 // ===== pugixml.hpp needed for pugi::impl::xml_memory_page_type_mask, pugi::xml_node_type, pugi::char_t, pugi::node_element, pugi::xml_node, pugi::xml_attribute, pugi::xml_document
 #include <external/pugixml/pugixml.hpp> // not sure why the full include path is needed within the header file
-#include <XLException.hpp>
+#include "XLException.hpp"
 
 namespace { // anonymous namespace to define constants / functions that shall not be exported from this module
     constexpr const int XLMaxNamespacedNameLen = 100;

--- a/OpenXLSX/headers/XLZipArchive.hpp
+++ b/OpenXLSX/headers/XLZipArchive.hpp
@@ -53,7 +53,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #endif // _MSC_VER
 
 // ===== OpenXLSX Includes ===== //
-#include "OpenXLSX-Exports.hpp"
+#include "include-exports-header.hpp"
 
 namespace Zippy
 {

--- a/OpenXLSX/headers/include-exports-header.hpp
+++ b/OpenXLSX/headers/include-exports-header.hpp
@@ -1,0 +1,5 @@
+#ifdef OPENXLSX_CMAKE
+#include "OpenXLSX-Exports.hpp"
+#else
+#include "swiftpm/OpenXLSX-Exports.hpp"
+#endif

--- a/OpenXLSX/module.modulemap
+++ b/OpenXLSX/module.modulemap
@@ -1,0 +1,6 @@
+module OpenXLSX {
+    header "OpenXLSX.hpp"
+    export *
+    requires cplusplus
+}
+

--- a/OpenXLSX/module.modulemap
+++ b/OpenXLSX/module.modulemap
@@ -1,4 +1,4 @@
-module OpenXLSX {
+module CxxOpenXLSX {
     header "OpenXLSX.hpp"
     export *
     requires cplusplus

--- a/OpenXLSX/sources/XLCell.cpp
+++ b/OpenXLSX/sources/XLCell.cpp
@@ -233,7 +233,7 @@ void XLCell::print(std::basic_ostream<char>& ostr) const { m_cellNode->print(ost
 /**
  * @details
  */
-XLCellAssignable::XLCellAssignable (XLCell const & other) : XLCell(other) {}
+XLCellAssignable::XLCellAssignable (XLCellAssignable const & other) : XLCell(other) {}
 
 /**
  * @details

--- a/OpenXLSX/sources/XLCell.cpp
+++ b/OpenXLSX/sources/XLCell.cpp
@@ -233,7 +233,7 @@ void XLCell::print(std::basic_ostream<char>& ostr) const { m_cellNode->print(ost
 /**
  * @details
  */
-XLCellAssignable::XLCellAssignable (XLCellAssignable const & other) : XLCell(other) {}
+XLCellAssignable::XLCellAssignable (XLCell const & other) : XLCell(other) {}
 
 /**
  * @details

--- a/OpenXLSX/swiftpm/OpenXLSX-Exports.hpp
+++ b/OpenXLSX/swiftpm/OpenXLSX-Exports.hpp
@@ -1,0 +1,42 @@
+
+#ifndef OPENXLSX_EXPORT_H
+#define OPENXLSX_EXPORT_H
+
+#ifdef OPENXLSX_STATIC_DEFINE
+#  define OPENXLSX_EXPORT
+#  define OPENXLSX_HIDDEN
+#else
+#  ifndef OPENXLSX_EXPORT
+#    ifdef OpenXLSX_EXPORTS
+        /* We are building this library */
+#      define OPENXLSX_EXPORT 
+#    else
+        /* We are using this library */
+#      define OPENXLSX_EXPORT 
+#    endif
+#  endif
+
+#  ifndef OPENXLSX_HIDDEN
+#    define OPENXLSX_HIDDEN 
+#  endif
+#endif
+
+#ifndef OPENXLSX_DEPRECATED
+#  define OPENXLSX_DEPRECATED __attribute__ ((__deprecated__))
+#endif
+
+#ifndef OPENXLSX_DEPRECATED_EXPORT
+#  define OPENXLSX_DEPRECATED_EXPORT OPENXLSX_EXPORT OPENXLSX_DEPRECATED
+#endif
+
+#ifndef OPENXLSX_DEPRECATED_NO_EXPORT
+#  define OPENXLSX_DEPRECATED_NO_EXPORT OPENXLSX_HIDDEN OPENXLSX_DEPRECATED
+#endif
+
+#if 0 /* DEFINE_NO_DEPRECATED */
+#  ifndef OPENXLSX_NO_DEPRECATED
+#    define OPENXLSX_NO_DEPRECATED
+#  endif
+#endif
+
+#endif /* OPENXLSX_EXPORT_H */

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,49 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "OpenXLSX",
+    products: [
+        .library(name: "OpenXLSX", targets: ["OpenXLSX"]),
+    ],
+    targets: [
+        .target(
+            name: "OpenXLSX",
+            path: "OpenXLSX",
+            sources: [
+                "sources/XLCell.cpp",
+                "sources/XLCellIterator.cpp",
+                "sources/XLCellRange.cpp",
+                "sources/XLCellReference.cpp",
+                "sources/XLCellValue.cpp",
+                "sources/XLColor.cpp",
+                "sources/XLColumn.cpp",
+                "sources/XLComments.cpp",
+                "sources/XLContentTypes.cpp",
+                "sources/XLDateTime.cpp",
+                "sources/XLDocument.cpp",
+                "sources/XLFormula.cpp",
+                "sources/XLMergeCells.cpp",
+                "sources/XLProperties.cpp",
+                "sources/XLRelationships.cpp",
+                "sources/XLRow.cpp",
+                "sources/XLRowData.cpp",
+                "sources/XLSharedStrings.cpp",
+                "sources/XLSheet.cpp",
+                "sources/XLStyles.cpp",
+                "sources/XLWorkbook.cpp",
+                "sources/XLXmlData.cpp",
+                "sources/XLXmlFile.cpp",
+                "sources/XLXmlParser.cpp",
+                "sources/XLZipArchive.cpp",
+            ],
+            publicHeadersPath: ".",
+            cxxSettings: [
+                .headerSearchPath("headers"),
+                .headerSearchPath("external/pugixml"),
+                .headerSearchPath("external/zippy"),
+            ]
+        ),
+    ],
+    cxxLanguageStandard: .cxx17
+)

--- a/Package.swift
+++ b/Package.swift
@@ -4,11 +4,11 @@ import PackageDescription
 let package = Package(
     name: "OpenXLSX",
     products: [
-        .library(name: "OpenXLSX", targets: ["OpenXLSX"]),
+        .library(name: "CxxOpenXLSX", targets: ["CxxOpenXLSX"]),
     ],
     targets: [
         .target(
-            name: "OpenXLSX",
+            name: "CxxOpenXLSX",
             path: "OpenXLSX",
             sources: [
                 "sources/XLCell.cpp",


### PR DESCRIPTION
This patch enables building OpenXLSX with SwiftPM.
SwiftPM is the package manager for the Swift programming language.
It can define packages implemented not only in Swift but also in C or C++, making it possible to use OpenXLSX from Swift by leveraging Swift’s C++ interoperability features.

Broadly, the following some changes were required:

# (1) Adding Package.swift and modulemap

A SwiftPM package requires the `Package.swift` file to be located directly under the root directory of the Git repository.
Additionally, C++ targets require a modulemap to enable Clang module support.

# ~~(2) Fixing the copy constructor of `XLCellAssignable`~~

~~Swift’s C++ interoperability requires that the copy constructor of the type being used is correctly defined.~~
~~In the copy constructor of `XLCellAssignable`, the argument type was `XLCell` instead of `XLCellAssignable`, which caused the Swift compiler to throw an error. This patch addresses and fixes this issue.~~

I have removed this change.

# (3) Changing header file includes from angle brackets to double quotes

In my configuration design, I set the header root of the OpenXLSX Clang module to correspond to the `OpenXLSX/` directory.
When headers within the module include other headers, using angle brackets caused errors, and it was necessary to use double quotes instead.

# (4) Pre-generating export headers and indirect inclusion

SwiftPM uses the repository directly as a package, but it cannot perform pre-processing steps such as running CMake. Therefore, it is necessary to either define settings in `Package.swift` or eliminate the need for CMake processing.
In particular, the export header `OpenXLSX-Exports.hpp` cannot be generated dynamically, so it must be pre-generated and committed to the repository.

To avoid altering the behavior of existing CMake builds, I implemented an indirect inclusion mechanism: when building with CMake, the generated header is included, and otherwise, the pre-generated header is used.
Instead of including `OpenXLSX-Exports.hpp` directly, I created a wrapper header file, `include-export-header.hpp`, which determines which export header to include based on the build context.