### PR TITLE
Use Quoted Includes for Header-to-Header Inclusion

### DIFF
--- a/OpenXLSX/headers/XLXmlParser.hpp
+++ b/OpenXLSX/headers/XLXmlParser.hpp
@@ -50,7 +50,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 
 // ===== pugixml.hpp needed for pugi::impl::xml_memory_page_type_mask, pugi::xml_node_type, pugi::char_t, pugi::node_element, pugi::xml_node, pugi::xml_attribute, pugi::xml_document
 #include <external/pugixml/pugixml.hpp> // not sure why the full include path is needed within the header file
-#include <XLException.hpp>
+#include "XLException.hpp"
 
 namespace { // anonymous namespace to define constants / functions that shall not be exported from this module
     constexpr const int XLMaxNamespacedNameLen = 100;


### PR DESCRIPTION
This PR is part of an effort to support SwiftPM (#293), but to keep things organized, I am splitting it into smaller, focused changes. This particular PR addresses one such change: modifying how `XLXmlParser.hpp` includes `XLException.hpp` by switching from angle brackets to quotes.

This change is necessary for SwiftPM compatibility.

To provide some context, there are two types of builds to consider:

1. **Building OpenXLSX itself**: In this case, there is no issue.
   - Both headers and sources are compiled together.
   - The OpenXLSX codebase requires the following search paths:
     - `OpenXLSX/`
     - `OpenXLSX/headers/`
     - `OpenXLSX/external/pugixml/`
     - `OpenXLSX/external/zippy/`
   - For example, the third search path is necessary because `XLCell.hpp` includes `#include <pugixml.hpp>`.

2. **Building targets that use OpenXLSX**: Here, SwiftPM's technical limitations introduce issues.
   - Unfortunately, SwiftPM's C++ targets can only configure one include path for a library, known as the public header directory.
   - Setting this path to `OpenXLSX/` allows the following includes:
     ```cxx
     #include <OpenXLSX.hpp>
     #include <headers/XLCell.hpp>
     #include <external/pugixml/pugixml.hpp>
     ```
   - However, these includes are not possible:
     ```cxx
     #include <XLCell.hpp>
     #include <pugixml.hpp>
     ```
     This is because `OpenXLSX/headers/` and `OpenXLSX/external/pugixml/` are not included in the include paths.

Luckily, this issue affects only the single location addressed by this patch. This is because, during the build of targets using OpenXLSX, headers are part of the compilation, but source files are not.

In the current codebase, pugixml includes are already written differently for headers and source files:
- In source files:
  ```cxx
  #include <pugixml.hpp>
  ```
- In header files:
  ```cxx
  #include <external/pugixml/pugixml.hpp>
  ```

To address this, we need to fix how `XLXmlParser.hpp` includes `XLException.hpp`. Both files are in the same directory, so using a quoted include resolves the path as a relative path:

```cxx
#include "XLException.hpp"
```

In fact, the following files already include `XLException.hpp` using quoted includes:

- XLCellValue.hpp
- XLComments.hpp
- XLDateTime.hpp
- XLRowData.hpp
- XLSheet.hpp
- XLXmlParser.hpp
- XLCellIterator.cpp
- XLCellReference.cpp
- XLCellValue.cpp
- XLColor.cpp
- XLDateTime.cpp

`XLXmlParser.hpp` is the only exception to this pattern, making it an outlier.
