### PR TITLE
Fix build for gcc13.3 (default on Ubuntu 24.04 LTS)

### DIFF
--- a/OpenXLSX/headers/XLCellReference.hpp
+++ b/OpenXLSX/headers/XLCellReference.hpp
@@ -56,6 +56,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #include <cstdint>    // Pull request #276
 #include <string>
 #include <utility>
+#include <cstdint>
 
 // ===== OpenXLSX Includes ===== //
 #include "OpenXLSX-Exports.hpp"

--- a/OpenXLSX/headers/XLColor.hpp
+++ b/OpenXLSX/headers/XLColor.hpp
@@ -55,6 +55,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 // ===== External Includes ===== //
 #include <cstdint>    // Pull request #276
 #include <string>
+#include <cstdint>
 
 // ===== OpenXLSX Includes ===== //
 #include "OpenXLSX-Exports.hpp"


### PR DESCRIPTION
Fixing following error message when building with gcc13.3 (default on Ubuntu 24.04 LTS)
```
<lib_dir>/OpenXLSX/headers/XLColor.hpp:172:9: error: ‘uint8_t’ does not name a type
  172 |         uint8_t green() const;
      |         ^~~~~~~ 
<lib_dir>/OpenXLSX/headers/XLColor.hpp:172:9: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
```

```
<lib_dir>/OpenXLSX/headers/XLCellReference.hpp:65:37: error: ‘uint32_t’ was not declared in this scope
   65 |     using XLCoordinates = std::pair<uint32_t, uint16_t>;
      |                                     ^~~~~~~~
<lib_dir>/OpenXLSX/headers/XLCellReference.hpp:59:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
```