### PR TITLE
BUG: doc.workbook().worksheet().column(1).width() changes column width!!!

### DIFF
--- a/OpenXLSX/headers/XLCommandQuery.hpp
+++ b/OpenXLSX/headers/XLCommandQuery.hpp
@@ -77,7 +77,8 @@ namespace OpenXLSX
         AddChartsheet,
         DeleteSheet,
         CloneSheet,
-        AddStyles
+        AddStyles,
+	AddPicture
     };
 
     /**

--- a/OpenXLSX/headers/XLComments.hpp
+++ b/OpenXLSX/headers/XLComments.hpp
@@ -196,6 +196,8 @@ namespace OpenXLSX
          * @return true upon success
          */
         bool setVmlDrawing(XLVmlDrawing &vmlDrawing);
+        bool setDrawing(XLDrawing &Drawing);
+
 
     private: // helper functions with repeating code
         XMLNode authorNode(uint16_t index) const;
@@ -259,6 +261,7 @@ namespace OpenXLSX
         XMLNode m_authors{};
         XMLNode m_commentList{};
         std::unique_ptr<XLVmlDrawing> m_vmlDrawing;
+        std::unique_ptr<XLDrawing> m_Drawing;
         mutable XMLNode m_hintNode{};                 // the last comment XML Node accessed by index is stored here, if any - will be reset when comments are inserted or deleted
         mutable size_t m_hintIndex{0};                // this has the index at which m_hintNode was accessed, only valid if not m_hintNode.empty()
         inline static const std::vector< std::string_view > m_nodeOrder = {      // comments XML node required child sequence

--- a/OpenXLSX/headers/XLContentTypes.hpp
+++ b/OpenXLSX/headers/XLContentTypes.hpp
@@ -255,6 +255,10 @@ namespace OpenXLSX
          */
         std::vector<XLContentItem> getContentItems();
 
+	bool PartNameExists(const std::string& path);
+	bool ExtensionExists(const std::string& ext);
+
+
     private:   // ---------- Private Member Variables ---------- //
     };
 }    // namespace OpenXLSX

--- a/OpenXLSX/headers/XLContentTypes.hpp
+++ b/OpenXLSX/headers/XLContentTypes.hpp
@@ -91,7 +91,7 @@ namespace OpenXLSX
         Comments,
         Table,
         VMLDrawing,
-    	Picture,
+        Image,
         Unknown
     };
 
@@ -228,6 +228,7 @@ namespace OpenXLSX
          * @param type The getValue
          */
         void addOverride(const std::string& path, XLContentType type);
+        void addDefault(const std::string& path, XLContentType type);
 
         /**
          * @brief

--- a/OpenXLSX/headers/XLContentTypes.hpp
+++ b/OpenXLSX/headers/XLContentTypes.hpp
@@ -91,6 +91,8 @@ namespace OpenXLSX
         Comments,
         Table,
         VMLDrawing,
+	Drawing,
+	Picture,
         Unknown
     };
 

--- a/OpenXLSX/headers/XLContentTypes.hpp
+++ b/OpenXLSX/headers/XLContentTypes.hpp
@@ -91,8 +91,7 @@ namespace OpenXLSX
         Comments,
         Table,
         VMLDrawing,
-	Drawing,
-	Picture,
+    	Picture,
         Unknown
     };
 

--- a/OpenXLSX/headers/XLDocument.hpp
+++ b/OpenXLSX/headers/XLDocument.hpp
@@ -69,7 +69,6 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #include "XLSharedStrings.hpp"
 #include "XLStyles.hpp"
 #include "XLTables.hpp"
-#include "XLPictures.hpp"
 #include "XLWorkbook.hpp"
 #include "XLXmlData.hpp"
 #include "XLZipArchive.hpp"
@@ -301,6 +300,7 @@ namespace OpenXLSX
          * @return true if vml drawing file exists
          */
         bool hasSheetVmlDrawing(uint16_t sheetXmlNo) const;
+
         bool hasSheetDrawing(uint16_t sheetXmlNo) const;
 
         /**
@@ -318,13 +318,6 @@ namespace OpenXLSX
         bool hasSheetTables(uint16_t sheetXmlNo) const;
 
         /**
-         * @brief determine whether a worksheet picture(s) file exists for sheetXmlNo
-         * @param sheetXmlNo check for this sheet number # (xl/media/image#.png)
-         * @return true if picture(s) file exists
-         */
-        bool hasSheetPictures(uint16_t sheetXmlNo) const;
-
-        /**
          * @brief fetch the worksheet relationships for sheetXmlNo, create the file if it does not exist
          * @param sheetXmlNo fetch for this sheet #
          * @return an XLRelationships object initialized with the sheet relationships
@@ -337,6 +330,12 @@ namespace OpenXLSX
          * @return an XLVmlDrawing object initialized with the sheet drawing
          */
         XLVmlDrawing sheetVmlDrawing(uint16_t sheetXmlNo);
+        /**
+          * @brief fetch the worksheet VML drawing for sheetXmlNo, create the file if it does not exist
+          * @param sheetXmlNo fetch for this sheet #
+          * @return an XLVmlDrawing object initialized with the sheet drawing
+          */
+ 
         XLDrawing sheetDrawing(uint16_t sheetXmlNo);
 
         /**
@@ -352,13 +351,6 @@ namespace OpenXLSX
          * @return an XLTables object initialized with the sheet tables
          */
         XLTables sheetTables(uint16_t sheetXmlNo);
-
-        /**
-         * @brief fetch the worksheet pictures for sheetXmlNo, create the file if it does not exist
-         * @param sheetXmlNo fetch for this sheet #
-         * @return an XLPictures object initialized with the sheet pictures
-         */
-        XLPictures sheetPictures(uint16_t sheetXmlNo);
 
         /**
          * @brief
@@ -399,6 +391,8 @@ namespace OpenXLSX
          * @note potentially time-intensive (on documents with many strings or many cells referring shared strings)
          */
         void cleanupSharedStrings();
+
+        int appendPictures(void* buffer, int bufferlen, char* ext,int col1,int row1,int col2,int row2);
 
         //----------------------------------------------------------------------------------------------------------------------
         //           Protected Member Functions
@@ -452,6 +446,8 @@ namespace OpenXLSX
 
         XLRelationships m_docRelationships {}; /**< A pointer to the document relationships object*/
         XLRelationships m_wbkRelationships {}; /**< A pointer to the document relationships object*/
+        XLRelationships m_drwRelationships {}; /**< A pointer to the document relationships object*/
+        XLRelationships m_wrkRelationships {}; /**< A pointer to the document relationships object*/
         XLContentTypes  m_contentTypes {};     /**< A pointer to the content types object*/
         XLAppProperties m_appProperties {};    /**< A pointer to the App properties object */
         XLProperties    m_coreProperties {};   /**< A pointer to the Core properties object*/

--- a/OpenXLSX/headers/XLDocument.hpp
+++ b/OpenXLSX/headers/XLDocument.hpp
@@ -69,6 +69,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #include "XLSharedStrings.hpp"
 #include "XLStyles.hpp"
 #include "XLTables.hpp"
+#include "XLPictures.hpp"
 #include "XLWorkbook.hpp"
 #include "XLXmlData.hpp"
 #include "XLZipArchive.hpp"
@@ -316,6 +317,13 @@ namespace OpenXLSX
         bool hasSheetTables(uint16_t sheetXmlNo) const;
 
         /**
+         * @brief determine whether a worksheet picture(s) file exists for sheetXmlNo
+         * @param sheetXmlNo check for this sheet number # (xl/media/image#.png)
+         * @return true if picture(s) file exists
+         */
+        bool hasSheetPictures(uint16_t sheetXmlNo) const;
+
+        /**
          * @brief fetch the worksheet relationships for sheetXmlNo, create the file if it does not exist
          * @param sheetXmlNo fetch for this sheet #
          * @return an XLRelationships object initialized with the sheet relationships
@@ -342,6 +350,13 @@ namespace OpenXLSX
          * @return an XLTables object initialized with the sheet tables
          */
         XLTables sheetTables(uint16_t sheetXmlNo);
+
+        /**
+         * @brief fetch the worksheet pictures for sheetXmlNo, create the file if it does not exist
+         * @param sheetXmlNo fetch for this sheet #
+         * @return an XLPictures object initialized with the sheet pictures
+         */
+        XLPictures sheetPictures(uint16_t sheetXmlNo);
 
         /**
          * @brief

--- a/OpenXLSX/headers/XLDocument.hpp
+++ b/OpenXLSX/headers/XLDocument.hpp
@@ -392,7 +392,9 @@ namespace OpenXLSX
          */
         void cleanupSharedStrings();
 
-        int appendPictures(void* buffer, int bufferlen, char* ext,int col1,int row1,int col2,int row2);
+        int appendPictures(int sheetXmlNo,void* buffer, int bufferlen, char* ext,int col1,int row1,int col2,int row2);
+	    void setShapeAttribute(int sheetXmlNo,int shapeNo,char *path,char *attribute,char *value);
+
 
         //----------------------------------------------------------------------------------------------------------------------
         //           Protected Member Functions

--- a/OpenXLSX/headers/XLDocument.hpp
+++ b/OpenXLSX/headers/XLDocument.hpp
@@ -301,6 +301,7 @@ namespace OpenXLSX
          * @return true if vml drawing file exists
          */
         bool hasSheetVmlDrawing(uint16_t sheetXmlNo) const;
+        bool hasSheetDrawing(uint16_t sheetXmlNo) const;
 
         /**
          * @brief determine whether a worksheet comments file exists for sheetXmlNo
@@ -336,6 +337,7 @@ namespace OpenXLSX
          * @return an XLVmlDrawing object initialized with the sheet drawing
          */
         XLVmlDrawing sheetVmlDrawing(uint16_t sheetXmlNo);
+        XLDrawing sheetDrawing(uint16_t sheetXmlNo);
 
         /**
          * @brief fetch the worksheet comments for sheetXmlNo, create the file if it does not exist

--- a/OpenXLSX/headers/XLDrawing.hpp
+++ b/OpenXLSX/headers/XLDrawing.hpp
@@ -471,9 +471,12 @@ namespace OpenXLSX
         XMLNode shapeNode(std::string const& cellRef) const;
         XMLNode shapeNode(uint32_t index) const;
 
-        XMLNode createShape();
+        XLShape shape(uint32_t index) const;
+        XLShape createShape();
 
         uint32_t shapeCount() const;
+
+        XMLNode rootNode() const;
 
     private: // helper functions with repeating code
         XMLNode firstShapeNode() const;

--- a/OpenXLSX/headers/XLDrawing.hpp
+++ b/OpenXLSX/headers/XLDrawing.hpp
@@ -408,6 +408,7 @@ namespace OpenXLSX
          */
         XLVmlDrawing& operator=(XLVmlDrawing&& other) noexcept = default;
 
+
     private: // helper functions with repeating code
         XMLNode firstShapeNode() const;
         XMLNode lastShapeNode() const;
@@ -441,9 +442,7 @@ namespace OpenXLSX
         uint32_t m_lastAssignedShapeId{0};
         std::string m_defaultShapeTypeId{};
     };
-    /**
-     * @brief The XLDrawing class is the base class for worksheet comments
-     */
+
     class OPENXLSX_EXPORT XLDrawing : public XLXmlFile
     {
         friend class XLWorksheet;   // for access to XLXmlFile::getXmlPath
@@ -453,37 +452,11 @@ namespace OpenXLSX
          * @brief Constructor
          */
         XLDrawing() : XLXmlFile(nullptr) {};
-
-        /**
-         * @brief The constructor.
-         * @param xmlData the source XML of the comments file
-         */
+        
         XLDrawing(XLXmlData* xmlData);
 
-        /**
-         * @brief The copy constructor.
-         * @param other The object to be copied.
-         * @note The default copy constructor is used, i.e. only shallow copying of pointer data members.
-         */
-        XLDrawing(const XLDrawing& other) = default;
-
-        /**
-         * @brief
-         * @param other
-         */
-        XLDrawing(XLDrawing&& other) noexcept = default;
-
-        /**
-         * @brief The destructor
-         * @note The default destructor is used, since cleanup of pointer data members is not required.
-         */
         ~XLDrawing() = default;
 
-        /**
-         * @brief Assignment operator
-         * @return A reference to the new object.
-         * @note The default assignment operator is used, i.e. only shallow copying of pointer data members.
-         */
         XLDrawing& operator=(const XLDrawing&) = default;
 
         /**
@@ -491,42 +464,10 @@ namespace OpenXLSX
          * @param other
          * @return
          */
+
         XLDrawing& operator=(XLDrawing&& other) noexcept = default;
 
-    private: // helper functions with repeating code
-        XMLNode firstShapeNode() const;
-        XMLNode lastShapeNode() const;
-        XMLNode shapeNode(uint32_t index) const;
-
-    public:
-
-        /**
-         * @brief Get the shape XML node that is associated with the cell indicated by cellRef
-         * @param cellRef the reference to the cell for which a shape shall be found
-         * @return the XMLNode that contains the desired shape, or an empty XMLNode if not found
-         */
-        XMLNode shapeNode(std::string const& cellRef) const;
-
-        uint32_t shapeCount() const;
-
-        XLShape shape(uint32_t index) const;
-
-        bool deleteShape(uint32_t index);
-        bool deleteShape(std::string const& cellRef);
-
-        XLShape createShape(const XLShape& shapeTemplate = XLShape());
-
-        /**
-         * @brief Print the XML contents of this XLDrawing instance using the underlying XMLNode print function
-         */
-        void print(std::basic_ostream<char>& ostr) const;
-
-    private:
-        uint32_t m_shapeCount{0};
-        uint32_t m_lastAssignedShapeId{0};
-        std::string m_defaultShapeTypeId{};
     };
 }    // namespace OpenXLSX
-
 
 #endif    // OPENXLSX_XLDRAWING_HPP

--- a/OpenXLSX/headers/XLDrawing.hpp
+++ b/OpenXLSX/headers/XLDrawing.hpp
@@ -271,6 +271,7 @@ namespace OpenXLSX
 
     class OPENXLSX_EXPORT XLShape {
         friend class XLVmlDrawing;    // for access to m_shapeNode in XLVmlDrawing::addShape
+        friend class XLDrawing;
     public:    // ---------- Public Member Functions ---------- //
         /**
          * @brief
@@ -466,6 +467,23 @@ namespace OpenXLSX
          */
 
         XLDrawing& operator=(XLDrawing&& other) noexcept = default;
+
+        XMLNode shapeNode(std::string const& cellRef) const;
+        XMLNode shapeNode(uint32_t index) const;
+
+        XMLNode createShape();
+
+        uint32_t shapeCount() const;
+
+    private: // helper functions with repeating code
+        XMLNode firstShapeNode() const;
+        XMLNode lastShapeNode() const;
+
+	private:
+		uint32_t m_shapeCount{0};
+        uint32_t m_lastAssignedShapeId{0};
+        std::string m_defaultShapeTypeId{};
+
 
     };
 }    // namespace OpenXLSX

--- a/OpenXLSX/headers/XLDrawing.hpp
+++ b/OpenXLSX/headers/XLDrawing.hpp
@@ -441,6 +441,92 @@ namespace OpenXLSX
         uint32_t m_lastAssignedShapeId{0};
         std::string m_defaultShapeTypeId{};
     };
+    /**
+     * @brief The XLDrawing class is the base class for worksheet comments
+     */
+    class OPENXLSX_EXPORT XLDrawing : public XLXmlFile
+    {
+        friend class XLWorksheet;   // for access to XLXmlFile::getXmlPath
+        friend class XLComments;    // for access to firstShapeNode
+    public:
+        /**
+         * @brief Constructor
+         */
+        XLDrawing() : XLXmlFile(nullptr) {};
+
+        /**
+         * @brief The constructor.
+         * @param xmlData the source XML of the comments file
+         */
+        XLDrawing(XLXmlData* xmlData);
+
+        /**
+         * @brief The copy constructor.
+         * @param other The object to be copied.
+         * @note The default copy constructor is used, i.e. only shallow copying of pointer data members.
+         */
+        XLDrawing(const XLDrawing& other) = default;
+
+        /**
+         * @brief
+         * @param other
+         */
+        XLDrawing(XLDrawing&& other) noexcept = default;
+
+        /**
+         * @brief The destructor
+         * @note The default destructor is used, since cleanup of pointer data members is not required.
+         */
+        ~XLDrawing() = default;
+
+        /**
+         * @brief Assignment operator
+         * @return A reference to the new object.
+         * @note The default assignment operator is used, i.e. only shallow copying of pointer data members.
+         */
+        XLDrawing& operator=(const XLDrawing&) = default;
+
+        /**
+         * @brief
+         * @param other
+         * @return
+         */
+        XLDrawing& operator=(XLDrawing&& other) noexcept = default;
+
+    private: // helper functions with repeating code
+        XMLNode firstShapeNode() const;
+        XMLNode lastShapeNode() const;
+        XMLNode shapeNode(uint32_t index) const;
+
+    public:
+
+        /**
+         * @brief Get the shape XML node that is associated with the cell indicated by cellRef
+         * @param cellRef the reference to the cell for which a shape shall be found
+         * @return the XMLNode that contains the desired shape, or an empty XMLNode if not found
+         */
+        XMLNode shapeNode(std::string const& cellRef) const;
+
+        uint32_t shapeCount() const;
+
+        XLShape shape(uint32_t index) const;
+
+        bool deleteShape(uint32_t index);
+        bool deleteShape(std::string const& cellRef);
+
+        XLShape createShape(const XLShape& shapeTemplate = XLShape());
+
+        /**
+         * @brief Print the XML contents of this XLDrawing instance using the underlying XMLNode print function
+         */
+        void print(std::basic_ostream<char>& ostr) const;
+
+    private:
+        uint32_t m_shapeCount{0};
+        uint32_t m_lastAssignedShapeId{0};
+        std::string m_defaultShapeTypeId{};
+    };
 }    // namespace OpenXLSX
+
 
 #endif    // OPENXLSX_XLDRAWING_HPP

--- a/OpenXLSX/headers/XLPictures.hpp
+++ b/OpenXLSX/headers/XLPictures.hpp
@@ -125,7 +125,9 @@ namespace OpenXLSX
         /**
          * @brief Print the XML contents of this XLPictures instance using the underlying XMLNode print function
          */
- 
+
+    void print(std::basic_ostream<char>& ostr) const;
+
 	int append(void *buffer,int bufferlen);
 
     };

--- a/OpenXLSX/headers/XLPictures.hpp
+++ b/OpenXLSX/headers/XLPictures.hpp
@@ -1,0 +1,134 @@
+/*
+
+   ____                               ____      ___ ____       ____  ____      ___
+  6MMMMb                              `MM(      )M' `MM'      6MMMMb\`MM(      )M'
+ 8P    Y8                              `MM.     d'   MM      6M'    ` `MM.     d'
+6M      Mb __ ____     ____  ___  __    `MM.   d'    MM      MM        `MM.   d'
+MM      MM `M6MMMMb   6MMMMb `MM 6MMb    `MM. d'     MM      YM.        `MM. d'
+MM      MM  MM'  `Mb 6M'  `Mb MMM9 `Mb    `MMd       MM       YMMMMb     `MMd
+MM      MM  MM    MM MM    MM MM'   MM     dMM.      MM           `Mb     dMM.
+MM      MM  MM    MM MMMMMMMM MM    MM    d'`MM.     MM            MM    d'`MM.
+YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
+ 8b    d8   MM.  ,M9 YM    d9 MM    MM  d'    `MM.   MM    / L    ,M9  d'    `MM.
+  YMMMM9    MMYMMM9   YMMMM9 _MM_  _MM_M(_    _)MM_ _MMMMMMM MYMMMM9 _M(_    _)MM_
+            MM
+            MM
+           _MM_
+
+  Copyright (c) 2018, Kenneth Troldal Balslev
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  - Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  - Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  - Neither the name of the author nor the
+    names of any contributors may be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ */
+
+#ifndef OPENXLSX_XLPICTURES_HPP
+#define OPENXLSX_XLPICTURES_HPP
+
+// ===== External Includes ===== //
+#include <cstdint>    // uint8_t, uint16_t, uint32_t
+#include <ostream>    // std::basic_ostream
+// #include <type_traits>
+// #include <variant>
+
+// ===== OpenXLSX Includes ===== //
+#include "OpenXLSX-Exports.hpp"
+// #include "XLDocument.hpp"
+#include "XLException.hpp"
+#include "XLXmlData.hpp"
+#include "XLXmlFile.hpp"
+
+namespace OpenXLSX
+{
+    /**
+     * @brief The XLPicturess class is the base class for worksheet pictures
+     */
+    class OPENXLSX_EXPORT XLPictures : public XLXmlFile
+    {
+        friend class XLWorksheet;   // for access to XLXmlFile::getXmlPath
+    public:
+        /**
+         * @brief Constructor
+         */
+        XLPictures() : XLXmlFile(nullptr) {};
+
+        /**
+         * @brief The constructor.
+         * @param xmlData the source XML of the picture file
+         */
+        XLPictures(XLXmlData* xmlData);
+
+        /**
+         * @brief The copy constructor.
+         * @param other The object to be copied.
+         * @note The default copy constructor is used, i.e. only shallow copying of pointer data members.
+         */
+        XLPictures(const XLPictures& other) = default;
+
+        /**
+         * @brief
+         * @param other
+         */
+        XLPictures(XLPictures&& other) noexcept = default;
+
+        /**
+         * @brief The destructor
+         * @note The default destructor is used, since cleanup of pointer data members is not required.
+         */
+        ~XLPictures() = default;
+
+        /**
+         * @brief Assignment operator
+         * @return A reference to the new object.
+         * @note The default assignment operator is used, i.e. only shallow copying of pointer data members.
+         */
+        XLPictures& operator=(const XLPictures&) = default;
+
+        /**
+         * @brief
+         * @param other
+         * @return
+         */
+        XLPictures& operator=(XLPictures&& other) noexcept = default;
+
+        // /**
+        //  * @brief getters
+        //  */
+        // std::string get(std::string cellRef) const;
+        // 
+        // /**
+        //  * @brief setters
+        //  */
+        // bool set(std::string cellRef);
+
+        /**
+         * @brief Print the XML contents of this XLPictures instance using the underlying XMLNode print function
+         */
+ 
+	int append(void *buffer,int bufferlen);
+
+    };
+}    // namespace OpenXLSX
+
+#endif    // OPENXLSX_XLPICTURES_HPP

--- a/OpenXLSX/headers/XLRelationships.hpp
+++ b/OpenXLSX/headers/XLRelationships.hpp
@@ -126,6 +126,7 @@ namespace OpenXLSX
         ControlProperties,
         Comments,
         Table,
+	    Picture,
         Unknown
     };
 } //     namespace OpenXLSX

--- a/OpenXLSX/headers/XLSheet.hpp
+++ b/OpenXLSX/headers/XLSheet.hpp
@@ -966,6 +966,9 @@ namespace OpenXLSX
          * @return
          */
         XLRowRange rows() const;
+     
+        float defaultColWidth() const;
+        float defaultRowHeight() const;
 
         /**
          * @brief

--- a/OpenXLSX/headers/XLSheet.hpp
+++ b/OpenXLSX/headers/XLSheet.hpp
@@ -75,8 +75,6 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #include "XLRow.hpp"
 #include "XLStyles.hpp"   // XLStyleIndex
 #include "XLTables.hpp"   // XLTables
-#include "XLPictures.hpp"   // XLPictures
-
 #include "XLXmlFile.hpp"
 
 namespace OpenXLSX
@@ -1212,8 +1210,11 @@ namespace OpenXLSX
          * @brief test whether a VML drawing XML file exists for this worksheet
          */
         bool hasVmlDrawing() const;
-        bool hasDrawing() const;
 
+        /**
+         * @brief test whether a drawing XML file exists for this worksheet
+         */
+        bool hasDrawing() const;
 
         /**
          * @brief test whether a comments XML file exists for this worksheet
@@ -1226,17 +1227,14 @@ namespace OpenXLSX
         bool hasTables() const;
 
         /**
-         * @brief test whether a pictures XML file exists for this worksheet
-         */
-        bool hasPictures() const;
-
-
-        /**
          * @brief fetch a reference to the worksheet VML drawing object
          */
-        XLVmlDrawing& vmlDrawing();
-        XLDrawing& Drawing();
-
+         XLVmlDrawing& vmlDrawing();
+ 
+         /**
+         * @brief fetch a reference to the worksheet VML drawing object
+         */
+        XLDrawing& drawing();
 
         /**
          * @brief fetch a reference to the worksheet comments
@@ -1247,11 +1245,6 @@ namespace OpenXLSX
          * @brief fetch a reference to the worksheet tables
          */
         XLTables& tables();
-
-        /**
-         * @brief fetch a reference to the worksheet picturees
-         */
-        XLPictures& pictures();
 
     private:
 
@@ -1307,9 +1300,7 @@ namespace OpenXLSX
         XLVmlDrawing    m_vmlDrawing{};       /**< class handling the worksheet VML drawing object */
         XLComments      m_comments{};         /**< class handling the worksheet comments */
         XLTables        m_tables{};           /**< class handling the worksheet table settings */
-        XLDrawing       m_Drawing {};      /**< class handling the worksheet drawing object */
-        XLPictures      m_pictures{};         /**< class handling the worksheet picture settings */
-	
+        XLDrawing       m_drawing{};          /**< class handling the worksheet drawing object */
         const std::vector< std::string_view >& m_nodeOrder = XLWorksheetNodeOrder;  // worksheet XML root node required child sequence
     };
 

--- a/OpenXLSX/headers/XLSheet.hpp
+++ b/OpenXLSX/headers/XLSheet.hpp
@@ -75,6 +75,8 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 #include "XLRow.hpp"
 #include "XLStyles.hpp"   // XLStyleIndex
 #include "XLTables.hpp"   // XLTables
+#include "XLPictures.hpp"   // XLPictures
+
 #include "XLXmlFile.hpp"
 
 namespace OpenXLSX
@@ -1222,6 +1224,12 @@ namespace OpenXLSX
         bool hasTables() const;
 
         /**
+         * @brief test whether a pictures XML file exists for this worksheet
+         */
+        bool hasPictures() const;
+
+
+        /**
          * @brief fetch a reference to the worksheet VML drawing object
          */
         XLVmlDrawing& vmlDrawing();
@@ -1235,6 +1243,11 @@ namespace OpenXLSX
          * @brief fetch a reference to the worksheet tables
          */
         XLTables& tables();
+
+        /**
+         * @brief fetch a reference to the worksheet picturees
+         */
+        XLPictures& pictures();
 
     private:
 
@@ -1290,6 +1303,8 @@ namespace OpenXLSX
         XLVmlDrawing    m_vmlDrawing{};       /**< class handling the worksheet VML drawing object */
         XLComments      m_comments{};         /**< class handling the worksheet comments */
         XLTables        m_tables{};           /**< class handling the worksheet table settings */
+        XLPictures      m_pictures{};         /**< class handling the worksheet picture settings */
+	
         const std::vector< std::string_view >& m_nodeOrder = XLWorksheetNodeOrder;  // worksheet XML root node required child sequence
     };
 

--- a/OpenXLSX/headers/XLSheet.hpp
+++ b/OpenXLSX/headers/XLSheet.hpp
@@ -1212,6 +1212,8 @@ namespace OpenXLSX
          * @brief test whether a VML drawing XML file exists for this worksheet
          */
         bool hasVmlDrawing() const;
+        bool hasDrawing() const;
+
 
         /**
          * @brief test whether a comments XML file exists for this worksheet
@@ -1233,6 +1235,8 @@ namespace OpenXLSX
          * @brief fetch a reference to the worksheet VML drawing object
          */
         XLVmlDrawing& vmlDrawing();
+        XLDrawing& Drawing();
+
 
         /**
          * @brief fetch a reference to the worksheet comments
@@ -1303,6 +1307,7 @@ namespace OpenXLSX
         XLVmlDrawing    m_vmlDrawing{};       /**< class handling the worksheet VML drawing object */
         XLComments      m_comments{};         /**< class handling the worksheet comments */
         XLTables        m_tables{};           /**< class handling the worksheet table settings */
+        XLDrawing       m_Drawing {};      /**< class handling the worksheet drawing object */
         XLPictures      m_pictures{};         /**< class handling the worksheet picture settings */
 	
         const std::vector< std::string_view >& m_nodeOrder = XLWorksheetNodeOrder;  // worksheet XML root node required child sequence

--- a/OpenXLSX/sources/XLComments.cpp
+++ b/OpenXLSX/sources/XLComments.cpp
@@ -204,6 +204,7 @@ XLComments& XLComments::operator=(XLComments&& other) noexcept
         m_authors          = std::move(other.m_authors);
         m_commentList      = std::move(other.m_commentList);
         m_vmlDrawing       = std::move(other.m_vmlDrawing);
+        m_Drawing          = std::move(other.m_Drawing);
         m_hintNode         = std::move(other.m_hintNode);
         m_hintIndex        = other.m_hintIndex;
     }
@@ -228,6 +229,12 @@ bool XLComments::setVmlDrawing(XLVmlDrawing &vmlDrawing)
     m_vmlDrawing = std::make_unique<XLVmlDrawing>(vmlDrawing);
     return true;
 }
+bool XLComments::setDrawing(XLDrawing &Drawing)
+{
+    m_Drawing = std::make_unique<XLDrawing>(Drawing);
+    return true;
+}
+
 
 /**
  * @details TODO: write doxygen headers for functions in this module

--- a/OpenXLSX/sources/XLContentTypes.cpp
+++ b/OpenXLSX/sources/XLContentTypes.cpp
@@ -361,3 +361,13 @@ std::vector<XLContentItem> XLContentTypes::getContentItems()
 
     return result;
 }
+
+bool XLContentTypes::PartNameExists(const std::string& path)
+{
+    return xmlDocument().document_element().find_child_by_attribute("PartName", path.c_str()) != nullptr;
+}
+
+bool XLContentTypes::ExtensionExists(const std::string& ext)
+{
+    return xmlDocument().document_element().find_child_by_attribute("Extension", ext.c_str()) != nullptr;
+}

--- a/OpenXLSX/sources/XLDocument.cpp
+++ b/OpenXLSX/sources/XLDocument.cpp
@@ -1508,7 +1508,9 @@ void XLDocument::setShapeAttribute(int sheetXmlNo,int shapeNo,char *path,char *a
                  }
              }
              if (att && val && i) {
-                 n.append_attribute(sa.data()) = sv.data();
+                 const pugi::char_t* a = (const pugi::char_t*)sa.data();
+                 if (n.attribute(a).empty())n.append_attribute(a) = sv.data();
+                 else n.attribute(a).set_value(sv.data());
                  att = 0;
                  val = 0;
                  if (!*s)break;
@@ -1536,7 +1538,8 @@ void XLDocument::setShapeAttribute(int sheetXmlNo,int shapeNo,char *path,char *a
      }
      if (attribute && *attribute) {
          const pugi::char_t* a = (const pugi::char_t*)attribute;
-         n.append_attribute(a) = value;
+         if(n.attribute(a).empty())n.append_attribute(a) = value;
+         else n.attribute(a).set_value(value);
      }
      else {
         if(value && *value)
@@ -1636,7 +1639,7 @@ int XLDocument::appendPictures(int sheetXmlNo,void* buffer, int bufferlen, char*
     geom.append_child("a:avLst");
     root.append_child("xdr:clientData");
  
-    return id;
+    return dr.shapeCount();
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/OpenXLSX/sources/XLDrawing.cpp
+++ b/OpenXLSX/sources/XLDrawing.cpp
@@ -666,3 +666,244 @@ XLShape XLVmlDrawing::createShape([[maybe_unused]] const XLShape& shapeTemplate 
  * @details Print the underlying XML using pugixml::xml_node::print
  */
 void XLVmlDrawing::print(std::basic_ostream<char>& ostr) const { xmlDocument().document_element().print( ostr ); }
+
+// ========== XLDrawing Member Functions
+
+/**
+ * @details The constructor creates an instance of the superclass, XLXmlFile
+ */
+XLDrawing::XLDrawing(XLXmlData* xmlData)
+ : XLXmlFile(xmlData)
+{
+    if (xmlData->getXmlType() != XLContentType::Drawing)
+        throw XLInternalError("XLDrawing constructor: Invalid XML data.");
+
+    XMLDocument & doc = xmlDocument();
+    if (doc.document_element().empty())   // handle a bad (no document element) drawing XML file
+        doc.load_string(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+            "<xml"
+            " xmlns:o=\"urn:schemas-microsoft-com:office:office\""
+            " xmlns:x=\"urn:schemas-microsoft-com:office:excel\""
+            " xmlns:w10=\"urn:schemas-microsoft-com:office:word\""
+            ">"
+            "\n</xml>",
+            pugi_parse_settings
+        );
+
+    // ===== Re-sort the document: move all v:shapetype nodes to the beginning of the XML document element and eliminate duplicates
+    // ===== Also: determine highest used shape id, regardless of basename (pattern [^0-9]*[0-9]*) and m_shapeCount
+    using namespace std::literals::string_literals;
+
+    XMLNode rootNode = doc.document_element();
+    XMLNode node = rootNode.first_child_of_type(pugi::node_element);
+    XMLNode lastShapeTypeNode{};
+    while (not node.empty()) {
+       XMLNode nextNode = node.next_sibling_of_type(pugi::node_element); // determine next node early because node may be invalidated by moveNode
+       if (node.raw_name() == ShapeTypeNodeName) {
+           if (wouldBeDuplicateShapeType(rootNode, node)) { // if shapetype attribute id already exists at begin of file
+               while(node.previous_sibling().type() == pugi::node_pcdata) // delete preceeding whitespaces
+                   rootNode.remove_child(node.previous_sibling());        //  ...
+               rootNode.remove_child(node);                               // and the v:shapetype node, as it can not be referenced for lack of a unique id
+           }
+           else
+               lastShapeTypeNode = moveNode(rootNode, node, lastShapeTypeNode); // move node to end of continuous list of shapetype nodes
+       }
+       else if (node.raw_name() == ShapeNodeName) {
+          ++m_shapeCount;
+          std::string strNodeId = node.attribute("id").value();
+          size_t pos = strNodeId.length();
+          uint32_t nodeId = 0;
+          while (pos > 0 && std::isdigit(strNodeId[--pos])) // determine any trailing nodeId
+              nodeId = 10*nodeId + strNodeId[pos] - '0';
+          m_lastAssignedShapeId = std::max(m_lastAssignedShapeId, nodeId);
+       }
+       node = nextNode;
+    }
+    // Henceforth: assume that it is safe to consider shape nodes a continuous list (well - unless there are other node types as well)
+
+    XMLNode shapeTypeNode{};
+    if (not lastShapeTypeNode.empty()) {
+        shapeTypeNode = rootNode.first_child_of_type(pugi::node_element);
+        while (not shapeTypeNode.empty() && shapeTypeNode.raw_name() != ShapeTypeNodeName)
+            shapeTypeNode = shapeTypeNode.next_sibling_of_type(pugi::node_element);
+    }
+    if (shapeTypeNode.empty()) {
+        shapeTypeNode = rootNode.prepend_child(ShapeTypeNodeName.c_str(), XLForceNamespace);
+        rootNode.prepend_child(pugi::node_pcdata).set_value("\n\t");
+    }
+    if (shapeTypeNode.first_child().empty())
+        shapeTypeNode.append_child(pugi::node_pcdata).set_value("\n\t"); // insert indentation if node was empty
+
+    // ===== Ensure that attributes exist for first shapetype node, default-initialize if needed:
+    m_defaultShapeTypeId = appendAndGetAttribute(shapeTypeNode, "id",        "_x0000_t202").value();
+    appendAndGetAttribute(shapeTypeNode, "coordsize", "21600,21600");
+    appendAndGetAttribute(shapeTypeNode, "o:spt",     "202");
+    appendAndGetAttribute(shapeTypeNode, "path",      "m,l,21600l21600,21600l21600,xe");
+
+    XMLNode strokeNode = shapeTypeNode.child("v:stroke");
+    if (strokeNode.empty()) {
+        strokeNode = shapeTypeNode.prepend_child("v:stroke", XLForceNamespace);
+        shapeTypeNode.prepend_child(pugi::node_pcdata).set_value("\n\t\t");
+    }
+    appendAndGetAttribute(strokeNode, "joinstyle", "miter");
+
+    XMLNode pathNode = shapeTypeNode.child("v:path");
+    if (pathNode.empty()) {
+        pathNode = shapeTypeNode.insert_child_after("v:path", strokeNode, XLForceNamespace);
+        copyLeadingWhitespaces(shapeTypeNode, strokeNode, pathNode);
+    }
+    appendAndGetAttribute(pathNode, "gradientshapeok", "t");
+    appendAndGetAttribute(pathNode, "o:connecttype", "rect");
+}
+
+
+/**
+ * @details get first shape node in document_element
+ * @return first shape node, empty node if none found
+ */
+XMLNode XLDrawing::firstShapeNode() const
+{
+    using namespace std::literals::string_literals;
+
+    XMLNode node = xmlDocument().document_element().first_child_of_type(pugi::node_element);
+    while (not node.empty() && node.raw_name() != ShapeNodeName)   // skip non shape nodes
+        node = node.next_sibling_of_type(pugi::node_element);
+    return node;
+}
+
+/**
+ * @details get last shape node in document_element
+ * @return last shape node, empty node if none found
+ */
+XMLNode XLDrawing::lastShapeNode() const
+{
+    using namespace std::literals::string_literals;
+
+    XMLNode node = xmlDocument().document_element().last_child_of_type(pugi::node_element);
+    while (not node.empty() && node.raw_name() != ShapeNodeName)
+        node = node.previous_sibling_of_type(pugi::node_element);
+    return node;
+}
+
+/**
+ * @details get last shape node at index in document_element
+ * @return shape node at index - throws if index is out of bounds
+ */
+XMLNode XLDrawing::shapeNode(uint32_t index) const
+{
+    using namespace std::literals::string_literals;
+
+    XMLNode node{}; // scope declaration, ensures node.empty() when index >= m_shapeCount
+    if (index < m_shapeCount) {
+        uint16_t i = 0;
+        node = firstShapeNode();
+        while (i != index && not node.empty() && node.raw_name() == ShapeNodeName) {   // follow shape index
+            ++i;
+            node = node.next_sibling_of_type(pugi::node_element);
+        }
+    }
+    if (node.empty() || node.raw_name() != ShapeNodeName)
+        throw XLException("XLDrawing: shape index "s + std::to_string(index) + " is out of bounds"s);
+
+    return node;
+}
+
+/**
+ * @details
+ */
+XMLNode XLDrawing::shapeNode(std::string const& cellRef) const
+{
+    XLCellReference destRef(cellRef);
+    uint32_t destRow = destRef.row() - 1;    // for accessing a shape: x:Row and x:Column are zero-indexed
+    uint16_t destCol = destRef.column() - 1; // ..
+
+    XMLNode node = firstShapeNode();
+    while (not node.empty()) {
+        if ((destRow == node.child("x:ClientData").child("x:Row").text().as_uint())
+          &&(destCol == node.child("x:ClientData").child("x:Column").text().as_uint()))
+    break; // found shape for cellRef
+
+        do { // locate next shape node
+            node = node.next_sibling_of_type(pugi::node_element);
+        } while (not node.empty() && node.name() != ShapeNodeName);
+    }
+    return node;
+}
+
+/**
+ * @details TODO: write doxygen headers for functions in this module
+ */
+uint32_t XLDrawing::shapeCount() const { return m_shapeCount; }
+
+/**
+ * @details TODO: write doxygen headers for functions in this module
+ */
+XLShape XLDrawing::shape(uint32_t index) const { return XLShape(shapeNode(index)); }
+
+/**
+ * @details TODO: write doxygen headers for functions in this module
+ */
+bool XLDrawing::deleteShape(uint32_t index)
+{
+    XMLNode rootNode = xmlDocument().document_element();
+    XMLNode node = shapeNode(index);   // returns a valid node or throws
+    --m_shapeCount;                    // if shapeNode(index) did not throw: decrement shape count
+    while (node.previous_sibling().type() == pugi::node_pcdata) // remove leading whitespaces
+        rootNode.remove_child(node.previous_sibling());
+    rootNode.remove_child(node);                                // then remove shape node itself
+
+    return true;
+}
+
+/**
+ * @details TODO: write doxygen headers for functions in this module
+ */
+bool XLDrawing::deleteShape(std::string const& cellRef)
+{
+    XMLNode rootNode = xmlDocument().document_element();
+    XMLNode node = shapeNode(cellRef);
+    if (node.empty()) return false;    // nothing found to delete
+
+    --m_shapeCount;                    // if shapeNode(cellRef) returned a non-empty node: decrement shape count
+    while (node.previous_sibling().type() == pugi::node_pcdata) // remove leading whitespaces
+        rootNode.remove_child(node.previous_sibling());
+    rootNode.remove_child(node);                                // then remove shape node itself
+
+    return true;
+}
+
+/**
+ * @details insert shape and return index
+ */
+XLShape XLDrawing::createShape([[maybe_unused]] const XLShape& shapeTemplate )
+{
+
+    XMLNode rootNode = xmlDocument().document_element();
+    XMLNode node = lastShapeNode();
+    if (node.empty()) {
+        node = rootNode.last_child_of_type(pugi::node_element);
+    }
+    if (not node.empty()) {                                                      // default case: a previous element node exists
+        node = rootNode.insert_child_after(ShapeNodeName.c_str(), node, XLForceNamespace);   // insert the node after the last shape node if any
+        copyLeadingWhitespaces(rootNode, node.previous_sibling(), node);                     // copy whitespaces from node after which this one was just inserted
+    }
+    else {                                                                       // else: shouldn't happen - but just in case
+        node = rootNode.prepend_child(ShapeNodeName.c_str(), XLForceNamespace);              // insert node prior to trailing whitespaces
+        rootNode.prepend_child(pugi::node_pcdata).set_value("\n\t");                         // prefix new node with whitespaces
+    }
+
+    // ===== Assign a new shape id & account for it in m_lastAssignedShapeId
+    using namespace std::literals::string_literals;
+    node.prepend_attribute("id").set_value(("shape_"s + std::to_string( m_lastAssignedShapeId++ )).c_str());
+    node.append_attribute("type").set_value(("#"s + m_defaultShapeTypeId).c_str());
+
+    m_shapeCount++;
+    return XLShape(node); // return object to manipulate new shape
+}
+
+
+/**
+ * @details Print the underlying XML using pugixml::xml_node::print
+ */
+void XLDrawing::print(std::basic_ostream<char>& ostr) const { xmlDocument().document_element().print( ostr ); }

--- a/OpenXLSX/sources/XLPictures.cpp
+++ b/OpenXLSX/sources/XLPictures.cpp
@@ -1,0 +1,105 @@
+/*
+
+   ____                               ____      ___ ____       ____  ____      ___
+  6MMMMb                              `MM(      )M' `MM'      6MMMMb\`MM(      )M'
+ 8P    Y8                              `MM.     d'   MM      6M'    ` `MM.     d'
+6M      Mb __ ____     ____  ___  __    `MM.   d'    MM      MM        `MM.   d'
+MM      MM `M6MMMMb   6MMMMb `MM 6MMb    `MM. d'     MM      YM.        `MM. d'
+MM      MM  MM'  `Mb 6M'  `Mb MMM9 `Mb    `MMd       MM       YMMMMb     `MMd
+MM      MM  MM    MM MM    MM MM'   MM     dMM.      MM           `Mb     dMM.
+MM      MM  MM    MM MMMMMMMM MM    MM    d'`MM.     MM            MM    d'`MM.
+YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
+ 8b    d8   MM.  ,M9 YM    d9 MM    MM  d'    `MM.   MM    / L    ,M9  d'    `MM.
+  YMMMM9    MMYMMM9   YMMMM9 _MM_  _MM_M(_    _)MM_ _MMMMMMM MYMMMM9 _M(_    _)MM_
+            MM
+            MM
+           _MM_
+
+  Copyright (c) 2018, Kenneth Troldal Balslev
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  - Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  - Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  - Neither the name of the author nor the
+    names of any contributors may be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ */
+
+// ===== External Includes ===== //
+// #include <algorithm>
+#include <pugixml.hpp>
+
+// ===== OpenXLSX Includes ===== //
+// #include "XLCellRange.hpp"
+// #include "XLDocument.hpp"
+#include "XLPictures.hpp"
+#include "utilities/XLUtilities.hpp"    // OpenXLSX::ignore
+
+using namespace OpenXLSX;
+
+namespace OpenXLSX
+{
+    // placeholder for utility functions
+
+}    // namespace OpenXLSX
+
+// ========== XLPictures Member Functions
+
+/**
+ * @details The constructor creates an instance of the superclass, XLXmlFile
+ */
+XLPictures::XLPictures(XLXmlData* xmlData) : XLXmlFile(xmlData)
+{
+    if (xmlData->getXmlType() != XLContentType::Picture)
+        throw XLInternalError("XLPictures constructor: Invalid XML data.");
+}
+
+/**
+ * @details getters
+ */
+/*
+std::string XLPictures::get(std::string cellRef) const
+{
+    OpenXLSX::ignore(cellRef);
+    return "";
+}
+*/
+
+/**
+ * @details setters
+ */
+/*
+bool XLPictures::set(std::string cellRef)
+{
+    OpenXLSX::ignore(cellRef);
+    return false;
+}
+*/
+
+/**
+ * @details Print the underlying XML using pugixml::xml_node::print
+ */
+void XLPictures::print(std::basic_ostream<char>& ostr) const { xmlDocument().document_element().print( ostr ); }
+
+int XLPictures::append(void *buffer,int bufferlen){
+int id=0;
+return id;
+}

--- a/OpenXLSX/sources/XLSharedStrings.cpp
+++ b/OpenXLSX/sources/XLSharedStrings.cpp
@@ -139,15 +139,15 @@ int32_t XLSharedStrings::appendString(const std::string& str) const
 
 /* Demo RTF - included
 <r>
-	<t>pri</t>
+    <t>pri</t>
 </r>
 <r>
-	<rPr>
-		<u/>
-		<i/>
-		<b/>
-	</rPr>
-	<t>vet</t>
+    <rPr>
+        <u/>
+        <i/>
+        <b/>
+    </rPr>
+    <t>vet</t>
 </r>
 */
 
@@ -160,21 +160,17 @@ int32_t XLSharedStrings::appendString(const std::string& str) const
         throw XLInternalError("XLSharedStrings::"s + __func__ + ": exceeded max strings count "s + std::to_string(XLMaxSharedStrings));
     }
     XMLNode textNode;
-    int r = 0;
     if (str.substr(0, 3) == "<r>") {
         textNode = xmlDocument().document_element().append_child("si");
-        r = 1;
-    }
-    else
-        textNode = xmlDocument().document_element().append_child("si").append_child("t");
-    if ((!str.empty()) && (str.front() == ' ' || str.back() == ' '))
-        textNode.append_attribute("xml:space").set_value("preserve");    // pull request #161
-    if (r)
         textNode.append_buffer((void*)str.c_str(), str.length(), 116U, pugi::encoding_auto);
-    else
+    }
+    else {
+        textNode = xmlDocument().document_element().append_child("si").append_child("t");
+        if ((!str.empty()) && (str.front() == ' ' || str.back() == ' '))
+            textNode.append_attribute("xml:space").set_value("preserve");    // pull request #161
         textNode.text().set(str.c_str());
-    m_stringCache->emplace_back(textNode.text().get());    // index of this element = previous stringCacheSize
-
+        m_stringCache->emplace_back(textNode.text().get());    // index of this element = previous stringCacheSize
+    }
     return static_cast<int32_t>(stringCacheSize);
 }
 

--- a/OpenXLSX/sources/XLSheet.cpp
+++ b/OpenXLSX/sources/XLSheet.cpp
@@ -92,8 +92,10 @@ namespace OpenXLSX
         unsigned int value       = (selected ? 1 : 0);
         XMLNode      sheetView   = xmlDocument.document_element().child("sheetViews").first_child_of_type(pugi::node_element);
         XMLAttribute tabSelected = sheetView.attribute("tabSelected");
-        if (tabSelected.empty())
+        if (tabSelected.empty()) {
             sheetView.prepend_attribute("tabSelected");    // BUGFIX 2024-05-01: create tabSelected attribute if it does not exist
+            tabSelected= sheetView.attribute("tabSelected");
+        }
         tabSelected.set_value(value);
     }
 

--- a/OpenXLSX/sources/XLSheet.cpp
+++ b/OpenXLSX/sources/XLSheet.cpp
@@ -92,10 +92,8 @@ namespace OpenXLSX
         unsigned int value       = (selected ? 1 : 0);
         XMLNode      sheetView   = xmlDocument.document_element().child("sheetViews").first_child_of_type(pugi::node_element);
         XMLAttribute tabSelected = sheetView.attribute("tabSelected");
-        if (tabSelected.empty()) {
-            sheetView.prepend_attribute("tabSelected");    // BUGFIX 2024-05-01: create tabSelected attribute if it does not exist
-            tabSelected= sheetView.attribute("tabSelected");
-        }
+        if (tabSelected.empty())
+            tabSelected = sheetView.prepend_attribute("tabSelected");    // BUGFIX 2024-05-01: create tabSelected attribute if it does not exist
         tabSelected.set_value(value);
     }
 

--- a/OpenXLSX/sources/XLSheet.cpp
+++ b/OpenXLSX/sources/XLSheet.cpp
@@ -994,6 +994,8 @@ XLWorksheet::XLWorksheet(const XLWorksheet& other) : XLSheetBase<XLWorksheet>(ot
     m_vmlDrawing    = other.m_vmlDrawing;     //  "     XLVmlDrawing
     m_comments      = other.m_comments;       //  "     XLComments         "
     m_tables        = other.m_tables;         //  "     XLTables           "
+    m_Drawing       = other.m_Drawing;        //  "     XLDrawing
+    m_pictures      = other.m_pictures;       //  "     XLPictures         "
 }
 
 /**
@@ -1006,6 +1008,10 @@ XLWorksheet::XLWorksheet(XLWorksheet&& other) : XLSheetBase< XLWorksheet >(other
     m_vmlDrawing    = std::move(other.m_vmlDrawing);     //  "     XLVmlDrawing
     m_comments      = std::move(other.m_comments);       //  "     XLComments         "
     m_tables        = std::move(other.m_tables);         //  "     XLTables           "
+    m_Drawing       = std::move(other.m_Drawing);        //  "     XLDrawing
+    m_pictures      = std::move(other.m_pictures);       //  "     XLPictures         "
+
+
 }
 
 /**
@@ -1019,6 +1025,9 @@ XLWorksheet& XLWorksheet::operator=(const XLWorksheet& other)
     m_vmlDrawing    = other.m_vmlDrawing;
     m_comments      = other.m_comments;
     m_tables        = other.m_tables;
+    m_Drawing       = other.m_Drawing;
+    m_pictures      = other.m_pictures;
+
     return *this;
 }
 
@@ -1033,6 +1042,9 @@ XLWorksheet& XLWorksheet::operator=(XLWorksheet&& other)
     m_vmlDrawing    = std::move(other.m_vmlDrawing);
     m_comments      = std::move(other.m_comments);
     m_tables        = std::move(other.m_tables);
+    m_Drawing       = std::move(other.m_Drawing);
+    m_pictures      = std::move(other.m_pictures);
+
     return *this;
 }
 
@@ -1627,12 +1639,15 @@ std::string XLWorksheet::sheetProtectionSummary() const
 }
 
 /**
- * @details functions to test whether a VMLDrawing / Comments / Tables entry exists for this worksheet (without creating those entries)
+ * @details functions to test whether a VMLDrawing / Comments / Tables /Drawing /Pictures entry exists for this worksheet (without creating those entries)
  */
 bool XLWorksheet::hasRelationships() const { return parentDoc().hasSheetRelationships(sheetXmlNumber()); }
 bool XLWorksheet::hasVmlDrawing()    const { return parentDoc().hasSheetVmlDrawing(   sheetXmlNumber()); }
 bool XLWorksheet::hasComments()      const { return parentDoc().hasSheetComments(     sheetXmlNumber()); }
 bool XLWorksheet::hasTables()        const { return parentDoc().hasSheetTables(       sheetXmlNumber()); }
+bool XLWorksheet::hasDrawing()       const { return parentDoc().hasSheetDrawing(      sheetXmlNumber()); }
+bool XLWorksheet::hasPictures()      const { return parentDoc().hasSheetPictures(     sheetXmlNumber()); }
+
 
 /**
  * @details fetches XLVmlDrawing for the sheet - creates & assigns the class if empty
@@ -1668,6 +1683,41 @@ XLVmlDrawing& XLWorksheet::vmlDrawing()
 
     return m_vmlDrawing;
 }
+/**
+ * @details fetches XLVmlDrawing for the sheet - creates & assigns the class if empty
+ */
+
+XLDrawing& XLWorksheet::Drawing()
+{
+    if (!m_Drawing.valid()) {
+        // ===== Append xdr namespace attribute to worksheet if not present
+        XMLNode docElement = xmlDocument().document_element();
+        XMLAttribute xdrNamespace = appendAndGetAttribute(docElement, "xmlns:xdr", "");
+        xdrNamespace = "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing";
+
+        std::ignore = relationships(); // create sheet relationships if not existing
+
+        // ===== Trigger parentDoc to create drawing XML file and return it
+        uint16_t sheetXmlNo = sheetXmlNumber();
+        m_Drawing = parentDoc().sheetDrawing(sheetXmlNo); // fetch drawing for this worksheet
+        if (!m_Drawing.valid())
+            throw XLException("XLWorksheet::Drawing(): could not create drawing XML");
+        std::string drawingRelativePath = getPathARelativeToPathB( m_Drawing.getXmlPath(), getXmlPath() );
+        XLRelationshipItem DrawingRelationship;
+        if (!m_relationships.targetExists(drawingRelativePath))
+            DrawingRelationship = m_relationships.addRelationship(XLRelationshipType::Drawing, drawingRelativePath);
+        else
+            DrawingRelationship = m_relationships.relationshipByTarget(drawingRelativePath);
+        if (DrawingRelationship.empty())
+            throw XLException("XLWorksheet::Drawing(): could not add determine sheet relationship for  Drawing");
+        XMLNode legacyDrawing = appendAndGetNode(docElement, "legacyDrawing", m_nodeOrder);
+        if (legacyDrawing.empty())
+            throw XLException("XLWorksheet::Drawing(): could not add <legacyDrawing> element to worksheet XML");
+        appendAndSetAttribute(legacyDrawing, "r:id", DrawingRelationship.id());
+    }
+
+    return m_Drawing;
+}
 
 /**
  * @details fetches XLComments for the sheet - creates & assigns the class if empty
@@ -1678,6 +1728,8 @@ XLComments& XLWorksheet::comments()
         std::ignore = relationships(); // create sheet relationships if not existing
         // ===== Unfortunately, xl/vmlDrawing#.vml is needed to support comments: append xdr namespace attribute to worksheet if not present
         std::ignore = vmlDrawing();    // create sheet VML drawing if not existing
+        std::ignore = Drawing();    // create sheet  drawing if not existing
+
 
 
         // ===== Trigger parentDoc to create comment XML file and return it
@@ -1687,6 +1739,7 @@ XLComments& XLWorksheet::comments()
         if (!m_comments.valid())
             throw XLException("XLWorksheet::comments(): could not create comments XML");
         m_comments.setVmlDrawing(m_vmlDrawing); // link XLVmlDrawing object to the comments so it can be modified from there
+        m_comments.setDrawing(m_Drawing); // link XLDrawing object to the comments so it can be modified from there
         std::string commentsRelativePath = getPathARelativeToPathB( m_comments.getXmlPath(), getXmlPath() );
         if (!m_relationships.targetExists(commentsRelativePath))
             m_relationships.addRelationship(XLRelationshipType::Comments, commentsRelativePath);
@@ -1717,6 +1770,30 @@ XLTables& XLWorksheet::tables()
 
     return m_tables;
 }
+
+/**
+ * @details fetches XLPictures for the sheet - creates & assigns the class if empty
+ */
+XLPictures& XLWorksheet::pictures()
+{
+    if (!m_pictures.valid()) {
+        std::ignore = relationships(); // create sheet relationships if not existing
+
+
+        // ===== Trigger parentDoc to create pictures XML file and return it
+        uint16_t sheetXmlNo = sheetXmlNumber();
+        // std::cout << "worksheet pictures for sheetId " << sheetXmlNo << std::endl;
+        m_pictures = parentDoc().sheetPictures(sheetXmlNo); // fetch pictures for this worksheet
+        if (!m_pictures.valid())
+            throw XLException("XLWorksheet::pictures(): could not create pictures XML");
+        std::string picturesRelativePath = getPathARelativeToPathB( m_pictures.getXmlPath(), getXmlPath() );
+        if (!m_relationships.targetExists(picturesRelativePath))
+            m_relationships.addRelationship(XLRelationshipType::Picture, picturesRelativePath);
+    }
+
+    return m_pictures;
+}
+
 
 /**
  * @details perform a pattern matching on getXmlPath for (regex) .*xl/worksheets/sheet([0-9]*)\.xml$ and extract the numeric part \1

--- a/OpenXLSX/sources/XLSheet.cpp
+++ b/OpenXLSX/sources/XLSheet.cpp
@@ -31,7 +31,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
     derived from this software without specific prior written permission.
 
   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IPLIED
   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
   DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
@@ -69,6 +69,19 @@ namespace OpenXLSX
      * @param xmlDocument XMLDocument object
      * @param color Thr color to set
      */
+
+    float XLWorksheet::defaultColWidth() const
+    {
+        if (!xmlDocument().document_element().child("sheetFormatPr"))return 9.8;
+	    return xmlDocument().document_element().child("sheetFormatPr").attribute("defaultColWidth").as_float();
+    }
+
+    float XLWorksheet::defaultRowHeight() const 
+    {
+    if (!xmlDocument().document_element().child("sheetFormatPr"))return 0;
+	return xmlDocument().document_element().child("sheetFormatPr").attribute("defaultRowHeight").as_float();
+    }
+
     void setTabColor(const XMLDocument& xmlDocument, const XLColor& color)
     {
         if (!xmlDocument.document_element().child("sheetPr")) xmlDocument.document_element().prepend_child("sheetPr");
@@ -1215,6 +1228,7 @@ XLColumn XLWorksheet::column(uint16_t columnNumber) const
 
     uint16_t minColumn {};
     uint16_t maxColumn {};
+    auto dcw = defaultColWidth();
     if (not columnNode.empty()) {
         minColumn = columnNode.attribute("min").as_int();    // only look it up once for multiple access
         maxColumn = columnNode.attribute("max").as_int();    //   "
@@ -1258,7 +1272,7 @@ XLColumn XLWorksheet::column(uint16_t columnNumber) const
         columnNode                                 = xmlDocument().document_element().child("cols").insert_child_before("col", columnNode);
         columnNode.append_attribute("min")         = columnNumber;
         columnNode.append_attribute("max")         = columnNumber;
-        columnNode.append_attribute("width")       = 9.8;    // NOLINT
+        columnNode.append_attribute("width")       = dcw;    // NOLINT
         columnNode.append_attribute("customWidth") = 0;
     }
 
@@ -1267,7 +1281,7 @@ XLColumn XLWorksheet::column(uint16_t columnNumber) const
         columnNode                                 = xmlDocument().document_element().child("cols").append_child("col");
         columnNode.append_attribute("min")         = columnNumber;
         columnNode.append_attribute("max")         = columnNumber;
-        columnNode.append_attribute("width")       = 9.8;    // NOLINT
+        columnNode.append_attribute("width")       = dcw;    // NOLINT
         columnNode.append_attribute("customWidth") = 0;
     }
 


### PR DESCRIPTION
When working with a third-party xlsx file, when calling the "column width" property, the column width changes (to 9.8). I suggest two new functions: XLWorksheet::defaultColWidth() and defaultRowHeight()