### PR TITLE
Please include XLException.hpp with double quote

### DIFF
--- a/OpenXLSX/headers/XLXmlParser.hpp
+++ b/OpenXLSX/headers/XLXmlParser.hpp
@@ -50,7 +50,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
 
 // ===== pugixml.hpp needed for pugi::impl::xml_memory_page_type_mask, pugi::xml_node_type, pugi::char_t, pugi::node_element, pugi::xml_node, pugi::xml_attribute, pugi::xml_document
 #include <external/pugixml/pugixml.hpp> // not sure why the full include path is needed within the header file
-#include <XLException.hpp>
+#include "XLException.hpp"
 
 namespace { // anonymous namespace to define constants / functions that shall not be exported from this module
     constexpr const int XLMaxNamespacedNameLen = 100;


### PR DESCRIPTION
There are two reasons.

1. To solve compile errors with some compilers (e.g. gcc 14).
2. Other header files are also included with double quotes. This file is the only exception.
