### PR TITLE
Fix captical typo

### DIFF
--- a/OpenXLSX/sources/XLContentTypes.cpp
+++ b/OpenXLSX/sources/XLContentTypes.cpp
@@ -71,7 +71,7 @@ namespace { // anonymous namespace for local functions
     {
         XLContentType type { XLContentType::Unknown };
 
-        if (typeString == applicationMicrosoftExcel + ".Sheet.macroEnabled.main+xml")
+        if (typeString == applicationMicrosoftExcel + ".sheet.macroEnabled.main+xml")
             type = XLContentType::WorkbookMacroEnabled;
         else if (typeString == applicationOpenXmlOfficeDocument + ".spreadsheetml.sheet.main+xml")
             type = XLContentType::Workbook;


### PR DESCRIPTION
Dear author, thanks for your wonderful work. 
I was using the OpenXLSX to write XLSX and XLSM.
I have checked [the related document](https://learn.microsoft.com/en-us/openspecs/office_standards/ms-offmacro2/fa1f6007-088f-4f54-ba65-83b5a9d635a6) and tested it with the real XLSM.
The letter should be lower case here. I have fixed this issue in this PR.
This content type can help us to judge current Excel is XLSX or XLSM.