### PR TITLE
Add missing XLCellAssignable copy constructor

### DIFF
--- a/OpenXLSX/headers/XLCell.hpp
+++ b/OpenXLSX/headers/XLCell.hpp
@@ -261,6 +261,7 @@ namespace OpenXLSX
          * @param other the cell to construct from
          */
         XLCellAssignable (XLCell const & other);
+        XLCellAssignable (XLCellAssignable const & other);
 
         /**
          * @brief Move constructor. Constructs an assignable XLCell from a temporary (r)value

--- a/OpenXLSX/sources/XLCell.cpp
+++ b/OpenXLSX/sources/XLCell.cpp
@@ -240,6 +240,11 @@ XLCellAssignable::XLCellAssignable (XLCell const & other) : XLCell(other) {}
 /**
  * @details
  */
+XLCellAssignable::XLCellAssignable (XLCellAssignable const & other) : XLCell(other) {}
+
+/**
+ * @details
+ */
 XLCellAssignable::XLCellAssignable (XLCell && other) : XLCell(std::move(other)) {}
 
 /**


### PR DESCRIPTION
This adds the missing `XLCellAssignable` copy constructor.

`XLCellAssignable` already has copy assignment operators, including assignment from another `XLCellAssignable`, so this appears to be an implementation oversight rather than an intentional non-copyable type.

The existing CMake/Catch tests also expect `XLCellAssignable` to be copy-constructible. In `Tests/testXLCell.cpp`, `XLWorksheet::cell()` returns `XLCellAssignable`, and the test copy-constructs it:

> ```cpp
> auto cell = wks.cell("A1");
> cell.value() = 42;
>
> auto copy = cell;
> ```

Without this constructor, the test target does not compile because the implicit copy constructor is deleted due to the user-declared move assignment operator.

This implementation delegates to the existing `XLCell` copy constructor, matching the behavior of the existing constructor from `XLCell const&`.