### PR TITLE
Return `false` from `hasFormula` for empty cells

### DIFF
--- a/OpenXLSX/sources/XLCell.cpp
+++ b/OpenXLSX/sources/XLCell.cpp
@@ -201,6 +201,7 @@ XLCell XLCell::offset(uint16_t rowOffset, uint16_t colOffset) const
  */
 bool XLCell::hasFormula() const
 {
+    if (empty()) return false;
     return (not m_cellNode->child("f").empty());    // evaluate child XMLNode as boolean
 }
 


### PR DESCRIPTION
This makes `XLCell::hasFormula()` safe to call on an empty/default-constructed cell.

The existing behavior dereferences the internal cell node unconditionally. For a default-constructed `XLCell`, that node is empty, so calling `hasFormula()` can crash instead of simply reporting that no formula exists.

The existing CMake/Catch tests already expect this API to be safe for empty cells. In `Tests/testXLCell.cpp`, the default-constructor test checks both the original empty cell and its copy:

> ```cpp
> XLCell cell;
> REQUIRE_FALSE(cell);
> REQUIRE_FALSE(cell.hasFormula());
>
> const auto copy = cell;
> REQUIRE_FALSE(copy);
> REQUIRE_FALSE(copy.hasFormula());
> ```

For an empty cell, returning `false` matches the natural meaning of the query: there is no formula.