### PR TITLE
Throw when requesting a reference from an empty cell

### DIFF
--- a/OpenXLSX/sources/XLCell.cpp
+++ b/OpenXLSX/sources/XLCell.cpp
@@ -183,7 +183,11 @@ XLCell::operator bool() const { return m_cellNode && (not m_cellNode->empty() );
 /**
  * @details This function returns a const reference to the cellReference property.
  */
-XLCellReference XLCell::cellReference() const { return XLCellReference { m_cellNode->attribute("r").value() }; }
+XLCellReference XLCell::cellReference() const
+{
+    if (empty()) throw XLException("XLCell object is empty");
+    return XLCellReference { m_cellNode->attribute("r").value() };
+}
 
 /**
  * @details This function returns a const reference to the cell reference by the offset from the current one.


### PR DESCRIPTION
This makes `XLCell::cellReference()` fail with an exception when called on an empty/default-constructed cell.

Previously, `cellReference()` unconditionally dereferenced the internal cell node. For an empty `XLCell`, that node is not available, so the call could crash instead of reporting the invalid operation through the existing exception mechanism.

The existing CMake/Catch tests already expect this behavior. In `Tests/testXLCell.cpp`, the default-constructor test checks that requesting a reference from both an empty cell and its copy throws:

> ```cpp
> XLCell cell;
> REQUIRE_FALSE(cell);
> REQUIRE_THROWS(cell.cellReference());
>
> const auto copy = cell;
> REQUIRE_FALSE(copy);
> REQUIRE_THROWS(copy.cellReference());
> ```

Since an empty cell has no address, throwing is consistent with the test expectation and avoids a null dereference.